### PR TITLE
Load .env at import

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -7,6 +7,8 @@ import logging
 
 from UI import run_streamlit
 
+load_dotenv()
+
 def main() -> None:
     """Execute the Streamlit UI."""
     logging.basicConfig(level=logging.INFO)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,11 +9,11 @@ class RunAppTest(unittest.TestCase):
     def test_main_invokes_run_streamlit(self) -> None:
         with patch("dotenv.load_dotenv") as mock_load:
             module = importlib.import_module("run_app")
-        mock_load.assert_not_called()
-        with patch.object(module, "load_dotenv") as mock_load, \
+        mock_load.assert_called_once()
+        with patch.object(module, "load_dotenv") as mock_load_main, \
                 patch.object(module, "run_streamlit") as mock_run:
             module.main()
-            mock_load.assert_called_once()
+            mock_load_main.assert_called_once()
             mock_run.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- load environment variables when importing `run_app`
- update `test_run_app` to expect `.env` is loaded at import time

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685c54559420832f82f3b8b9c141f0ee