### PR TITLE
Add Turkish header support for Excel claims search

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -40,6 +40,14 @@ class ExcelClaimsSearcher:
         rows = ws.iter_rows(values_only=True)
         try:
             headers = [str(c).strip().lower() if c is not None else "" for c in next(rows)]
+            mapping = {
+                "müşteri şikayeti": "complaint",
+                "müşteri": "customer",
+                "konu": "subject",
+                "parça kodu": "part_code",
+                "tarih": "date",
+            }
+            headers = [mapping.get(h, h) for h in headers]
         except StopIteration:
             wb.close()
             return []

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -10,10 +10,12 @@ from openpyxl import Workbook
 class ExcelClaimsSearchTest(unittest.TestCase):
     """Tests for ExcelClaimsSearcher.search."""
 
-    def _create_file(self, path: str) -> None:
+    def _create_file(self, path: str, headers=None) -> None:
         wb = Workbook()
         ws = wb.active
-        ws.append(["complaint", "customer", "subject", "part_code", "date"])
+        if headers is None:
+            headers = ["complaint", "customer", "subject", "part_code", "date"]
+        ws.append(headers)
         ws.append(["noise", "ACME", "engine", "X1", datetime(2023, 1, 1)])
         ws.append(["crack", "BETA", "body", "X2", datetime(2022, 5, 1)])
         wb.save(path)
@@ -28,6 +30,24 @@ class ExcelClaimsSearchTest(unittest.TestCase):
             self.assertEqual(result[0]["customer"], "ACME")
             empty = searcher.search({"customer": "ACME"}, year=2022)
             self.assertEqual(empty, [])
+
+    def test_turkish_headers(self) -> None:
+        """Ensure search works when headers are Turkish."""
+        headers = [
+            "müşteri şikayeti",
+            "müşteri",
+            "konu",
+            "parça kodu",
+            "tarih",
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "claims.xlsx")
+            self._create_file(file_path, headers=headers)
+            searcher = ExcelClaimsSearcher(file_path)
+            result = searcher.search({"customer": "ACME"}, year=2023)
+            self.assertEqual(len(result), 1)
+            self.assertIn("customer", result[0])
+            self.assertEqual(result[0]["customer"], "ACME")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support Turkish column headers in ExcelClaimsSearcher
- update tests to verify Turkish headers work in searches

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685c5a6426f4832f8f794d0d2e95e10c