### PR TITLE
Enlarge logo display size

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -57,7 +57,8 @@ def main() -> None:
     logo_path = Path(__file__).resolve().parents[1] / "Logo" / "logo.png"
     if logo_path.exists():
         cols = st.columns(3)
-        cols[1].image(str(logo_path), width=60)
+        # Display the logo at four times the previous width
+        cols[1].image(str(logo_path), width=240)
     st.markdown(
         "<h1 style='text-align: center; font-size: 64px;'>PLASMA PLASTİK</h1>",
         unsafe_allow_html=True,

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -77,7 +77,7 @@ class StreamlitAppTest(unittest.TestCase):
             self.dummy_st.set_page_config.assert_called_once()
             self.dummy_st.columns.assert_called()
             expected_logo = Path(module.__file__).resolve().parents[1] / "Logo" / "logo.png"
-            self.dummy_st.image.assert_called_once_with(str(expected_logo), width=60)
+            self.dummy_st.image.assert_called_once_with(str(expected_logo), width=240)
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- enlarge `logo.png` to 4x its original dimensions
- show the logo wider in the Streamlit UI
- update tests for new logo width

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685c5b75544c832f9f40e6fbb89a0dd6