### PR TITLE
Display logo in sidebar

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -72,9 +72,7 @@ def main() -> None:
 
     logo_path = Path(__file__).resolve().parents[1] / "Logo" / "logo.png"
     if logo_path.exists():
-        cols = st.columns(3)
-        # Display the logo at four times the previous width
-        cols[1].image(str(logo_path), width=240)
+        st.sidebar.image(str(logo_path), use_column_width=True)
     st.markdown(
         "<h1 style='text-align: center; font-size: 64px;'>PLASMA PLASTİK</h1>",
         unsafe_allow_html=True,

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -25,12 +25,12 @@ class StreamlitAppTest(unittest.TestCase):
         dummy_st.json = MagicMock()
         dummy_st.download_button = MagicMock()
         dummy_st.markdown = MagicMock()
-        dummy_st.image = MagicMock()
         sidebar = types.SimpleNamespace(
             markdown=MagicMock(),
             text_input=MagicMock(return_value="q"),
             button=MagicMock(return_value=False),
             json=MagicMock(),
+            image=MagicMock(),
         )
         dummy_st.sidebar = sidebar
 
@@ -77,7 +77,9 @@ class StreamlitAppTest(unittest.TestCase):
             self.dummy_st.set_page_config.assert_called_once()
             self.dummy_st.columns.assert_called()
             expected_logo = Path(module.__file__).resolve().parents[1] / "Logo" / "logo.png"
-            self.dummy_st.image.assert_called_once_with(str(expected_logo), width=240)
+            self.dummy_st.sidebar.image.assert_called_once_with(
+                str(expected_logo), use_column_width=True
+            )
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- show logo in the Streamlit sidebar so it stays pinned on screen
- update unit test expectations for sidebar logo placement

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685c61b9c090832fa4c88cf9b70001d5