### PR TITLE
Improve complaint search with normalization

### DIFF
--- a/ComplaintSearch/__init__.py
+++ b/ComplaintSearch/__init__.py
@@ -4,9 +4,20 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import re
+import unicodedata
+from difflib import SequenceMatcher
 from typing import Dict, List
 
-from .claims_excel import ExcelClaimsSearcher
+
+def normalize_text(text: str) -> str:
+    """Return lowercase ASCII text without punctuation or extra spaces."""
+    text_norm = unicodedata.normalize("NFKD", text)
+    ascii_text = text_norm.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_text.lower()
+    no_punct = re.sub(r"[^\w\s]", "", lowered)
+    collapsed = re.sub(r"\s+", " ", no_punct)
+    return collapsed.strip()
 
 
 class ComplaintStore:
@@ -33,23 +44,33 @@ class ComplaintStore:
             json.dump(data, f, ensure_ascii=False, indent=2)
 
     def search(self, keyword: str) -> List[Dict[str, str]]:
-        """Return complaint records containing ``keyword``."""
+        """Return complaint records fuzzy-matching ``keyword``."""
         if not self.path.exists():
             return []
+
         with open(self.path, "r", encoding="utf-8") as f:
             try:
                 items: List[Dict[str, str]] = json.load(f)
             except json.JSONDecodeError:
                 return []
-        keyword = keyword.lower()
+
+        keyword_norm = normalize_text(keyword)
         results = []
+
         for item in items:
-            if any(
-                keyword in str(item.get(field, "")).lower()
-                for field in ["complaint", "customer", "subject", "part_code"]
-            ):
-                results.append(item)
+            for field in ["complaint", "customer", "subject", "part_code"]:
+                value = str(item.get(field, ""))
+                value_norm = normalize_text(value)
+                if keyword_norm in value_norm:
+                    results.append(item)
+                    break
+                ratio = SequenceMatcher(None, keyword_norm, value_norm).ratio()
+                if ratio >= 0.8:
+                    results.append(item)
+                    break
         return results
 
+
+from .claims_excel import ExcelClaimsSearcher
 
 __all__ = ["ComplaintStore", "ExcelClaimsSearcher"]

--- a/tests/test_complaint_search.py
+++ b/tests/test_complaint_search.py
@@ -24,6 +24,31 @@ class ComplaintStoreTest(unittest.TestCase):
             results_empty = store.search("missing")
             self.assertEqual(results_empty, [])
 
+    def test_normalization_and_fuzzy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/complaints.json"
+            store = ComplaintStore(path)
+            store.add_complaint({
+                "complaint": "M\u015fteri \u015fikayet",  # includes accents
+                "customer": "ACME",
+                "subject": "engine",
+                "part_code": "X1",
+            })
+            store.add_complaint({
+                "complaint": "noise issue",
+                "customer": "BETA",
+                "subject": "door",
+                "part_code": "X2",
+            })
+
+            accent = store.search("sikayet")
+            self.assertEqual(len(accent), 1)
+            self.assertEqual(accent[0]["customer"], "ACME")
+
+            typo = store.search("noize issue")
+            self.assertEqual(len(typo), 1)
+            self.assertEqual(typo[0]["customer"], "BETA")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `normalize_text` helper
- fuzzy matching in `ComplaintStore.search`
- normalize and fuzzy match Excel search
- test accent stripping and typos across search utilities

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685c69e5b398832f98f07123ef7f74d5