### PR TITLE
Adjust dotenv loading

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -7,7 +7,6 @@ import logging
 
 from UI import run_streamlit
 
-load_dotenv()
 
 def main() -> None:
     """Execute the Streamlit UI."""

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,7 +9,7 @@ class RunAppTest(unittest.TestCase):
     def test_main_invokes_run_streamlit(self) -> None:
         with patch("dotenv.load_dotenv") as mock_load:
             module = importlib.import_module("run_app")
-        mock_load.assert_called_once()
+        mock_load.assert_not_called()
         with patch.object(module, "load_dotenv") as mock_load_main, \
                 patch.object(module, "run_streamlit") as mock_run:
             module.main()


### PR DESCRIPTION
## Summary
- load env vars inside `main()` in `run_app.py`
- update tests for the new behavior

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d1376735c832faa1f1f06fe0375a7