### PR TITLE
Update sidebar image width argument

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -89,7 +89,7 @@ def main() -> None:
 
     logo_path = Path(__file__).resolve().parents[1] / "Logo" / "logo.png"
     if logo_path.exists():
-        st.sidebar.image(str(logo_path), use_column_width=True)
+        st.sidebar.image(str(logo_path), use_container_width=True)
 
     if st_option_menu:
         st_option_menu(

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -78,7 +78,7 @@ class StreamlitAppTest(unittest.TestCase):
             self.dummy_st.columns.assert_called()
             expected_logo = Path(module.__file__).resolve().parents[1] / "Logo" / "logo.png"
             self.dummy_st.sidebar.image.assert_called_once_with(
-                str(expected_logo), use_column_width=True
+                str(expected_logo), use_container_width=True
             )
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")


### PR DESCRIPTION
## Summary
- align streamlit sidebar image width argument with latest API
- adapt tests to check for `use_container_width`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d1b0d4c20832fb1e4f668ce432bec