### PR TITLE
Update heading styling

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -27,7 +27,7 @@ st.set_page_config(
 
 st.markdown(
     """
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap"
           rel="stylesheet">
     <style>
         body {
@@ -41,6 +41,8 @@ st.markdown(
         }
         h1 {
             font-size: 3rem;
+            color: #193C6B;
+            font-family: 'Montserrat', sans-serif;
         }
         div[data-testid="stSidebar"] {
             background-color: #2E4053;
@@ -93,7 +95,7 @@ def main() -> None:
 
 
     st.markdown(
-        "<h1 style='text-align: center; font-size: 64px;'>PLASMA PLASTİK</h1>",
+        "<h1 style='text-align: center;'>PLASMA PLASTİK</h1>",
         unsafe_allow_html=True,
     )
     st.sidebar.markdown("### Search Complaints")


### PR DESCRIPTION
## Summary
- switch Google Fonts to Montserrat 700
- style `<h1>` with Montserrat and new color
- simplify title markup

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d24b9ecf8832f9cccd04b1d901da5