### PR TITLE
Render logo in header

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -90,12 +90,11 @@ def main() -> None:
     """Run the Streamlit application."""
 
     logo_path = Path(__file__).resolve().parents[1] / "Logo" / "logo.png"
+    col_logo, col_title = st.columns([1, 3])
     if logo_path.exists():
-        st.sidebar.image(str(logo_path), use_container_width=True)
-
-
-    st.markdown(
-        "<h1 style='text-align: center;'>PLASMA PLASTİK</h1>",
+        col_logo.image(str(logo_path), use_container_width=True)
+    col_title.markdown(
+        "<h1 style='text-align: left;'>PLASMA PLASTİK</h1>",
         unsafe_allow_html=True,
     )
     st.sidebar.markdown("### Search Complaints")

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -25,6 +25,7 @@ class StreamlitAppTest(unittest.TestCase):
         dummy_st.json = MagicMock()
         dummy_st.download_button = MagicMock()
         dummy_st.markdown = MagicMock()
+        dummy_st.image = MagicMock()
         sidebar = types.SimpleNamespace(
             markdown=MagicMock(),
             text_input=MagicMock(return_value="q"),
@@ -34,8 +35,9 @@ class StreamlitAppTest(unittest.TestCase):
         )
         dummy_st.sidebar = sidebar
 
-        def columns(num: int):
-            return [dummy_st for _ in range(num)]
+        def columns(spec):
+            count = spec if isinstance(spec, int) else len(spec)
+            return [dummy_st for _ in range(count)]
 
         dummy_st.columns = MagicMock(side_effect=columns)
 
@@ -76,6 +78,8 @@ class StreamlitAppTest(unittest.TestCase):
 
             self.dummy_st.set_page_config.assert_called_once()
             self.dummy_st.columns.assert_called()
+            self.assertTrue(self.dummy_st.image.called)
+            self.dummy_st.sidebar.image.assert_not_called()
 
             m_open.assert_any_call(Path("reports") / "LLM1.txt", "w", encoding="utf-8")
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")
@@ -120,6 +124,7 @@ class StreamlitSearchTest(unittest.TestCase):
         dummy_st.json = MagicMock()
         dummy_st.download_button = MagicMock()
         dummy_st.markdown = MagicMock()
+        dummy_st.image = MagicMock()
         sidebar = types.SimpleNamespace(
             markdown=MagicMock(),
             text_input=MagicMock(return_value="k"),


### PR DESCRIPTION
## Summary
- display the logo and heading using `st.columns`
- ensure sidebar doesn't render the logo
- verify new behaviour in streamlit tests

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d26264938832fb49d9c5ee68ad555