### PR TITLE
Update header logo and adjust tests

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -90,8 +90,8 @@ st.markdown(
 METHODS = ["8D", "5N1K", "A3", "DMAIC", "Ishikawa"]
 
 
-def main() -> None:
-    """Run the Streamlit application."""
+def place_logo() -> None:
+    """Display the logo and heading in the header."""
 
     logo_path = Path(__file__).resolve().parents[1] / "Logo" / "logo.png"
     col_logo, col_title = st.columns([1, 3])
@@ -101,6 +101,12 @@ def main() -> None:
         "<h1 style='text-align: left;'>PLASMA PLASTİK</h1>",
         unsafe_allow_html=True,
     )
+
+
+def main() -> None:
+    """Run the Streamlit application."""
+
+    place_logo()
     st.sidebar.markdown("### Search Complaints")
     search_term = st.sidebar.text_input("Keyword", key="keyword")
     if st.sidebar.button("🔍 Search", key="search"):

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -55,7 +55,8 @@ class StreamlitAppTest(unittest.TestCase):
     def test_main_pipeline(self) -> None:
         module = importlib.import_module("UI.streamlit_app")
         m_open = mock_open(read_data=b"data")
-        with patch.object(module, "GuideManager") as mock_manager, \
+        with patch.object(module, "place_logo", wraps=module.place_logo) as mock_logo, \
+             patch.object(module, "GuideManager") as mock_manager, \
              patch.object(module, "LLMAnalyzer") as mock_analyzer, \
              patch.object(module, "ReportGenerator") as mock_report, \
              patch.object(module, "Review") as mock_review, \
@@ -76,6 +77,7 @@ class StreamlitAppTest(unittest.TestCase):
 
             module.main()
 
+            mock_logo.assert_called_once()
             self.dummy_st.set_page_config.assert_called_once()
             self.dummy_st.columns.assert_called()
             self.assertTrue(self.dummy_st.image.called)


### PR DESCRIPTION
## Summary
- add `place_logo` helper and call from `main`
- check `place_logo` call in Streamlit tests

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d2aa2fe44832fb0a7c306ef230bac