### PR TITLE
Add directives support in UI and CLI

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -98,8 +98,13 @@ class LLMAnalyzer:
             self.logger.debug("LLMAnalyzer._query_llm end")
             return f"LLM response placeholder for: {user_prompt[:50]}"
 
-    def analyze(self, details: Dict[str, Any], guideline: Dict[str, Any]) -> Dict[str, Any]:
-        """Return analysis results per guideline step using complaint details."""
+    def analyze(
+        self,
+        details: Dict[str, Any],
+        guideline: Dict[str, Any],
+        directives: str = "",
+    ) -> Dict[str, Any]:
+        """Return analysis using complaint details and optional directives."""
         complaint_text = details.get("complaint", "")
         customer = details.get("customer", "")
         subject = details.get("subject", "")
@@ -115,6 +120,12 @@ class LLMAnalyzer:
                 f"Parça Kodu: {part_code}\n"
                 f"Problem Açıklaması: {subject or complaint_text}"
             )
+            if directives:
+                user_prompt += (
+                    "\n---\nKullanıcıdan gelen özel talimatlar:\n"
+                    f"{directives}\n\n"
+                    "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
+                )
             answer = self._query_llm(DEFAULT_8D_PROMPT, user_prompt)
             return {"full_text": answer}
 
@@ -126,6 +137,12 @@ class LLMAnalyzer:
                 .replace("{{parca_kodu}}", part_code)
                 .replace("{{problem_aciklamasi}}", subject or complaint_text)
             )
+            if directives:
+                user_prompt += (
+                    "\n---\nKullanıcıdan gelen özel talimatlar:\n"
+                    f"{directives}\n\n"
+                    "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
+                )
             answer = self._query_llm("", user_prompt)
             return {"full_text": answer}
 
@@ -163,6 +180,12 @@ class LLMAnalyzer:
                 step_entry = template.get(step_id, {})
                 system_prompt = step_entry.get("system", "").format(**values)
                 user_prompt = step_entry.get("user_template", "").format(**values)
+            if directives:
+                user_prompt += (
+                    "\n---\nKullanıcıdan gelen özel talimatlar:\n"
+                    f"{directives}\n\n"
+                    "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
+                )
 
             answer = self._query_llm(system_prompt, user_prompt)
             results[step_id] = {"response": answer}

--- a/UI/cli.py
+++ b/UI/cli.py
@@ -27,6 +27,7 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument("--customer", help="Customer name")
     parser.add_argument("--subject", help="Complaint subject")
     parser.add_argument("--part-code", help="Related part code")
+    parser.add_argument("--directives", help="Additional user directives")
     parser.add_argument("--search", help="Search past complaints")
     return parser.parse_args(args)
 
@@ -47,6 +48,7 @@ def main(args: Optional[List[str]] = None) -> None:
     customer = options.customer or input("Customer: ")
     subject = options.subject or input("Subject: ")
     part_code = options.part_code or input("Part code: ")
+    directives = options.directives or input("Directives: ")
 
     manager = GuideManager()
     guideline = manager.get_format(method)
@@ -59,7 +61,7 @@ def main(args: Optional[List[str]] = None) -> None:
         "part_code": part_code,
     }
     ComplaintStore().add_complaint(details)
-    analysis = analyzer.analyze(details, guideline)
+    analysis = analyzer.analyze(details, guideline, directives)
 
     out_dir = Path(options.output)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -159,6 +159,10 @@ def main() -> None:
         help="Identifier of the affected part or product",
         key="part_code",
     )
+    user_directives = st.text_area(
+        "Ek özel talimatlar/uyarılar",
+        key="directives",
+    )
     st.markdown("</div>", unsafe_allow_html=True)
 
     st.markdown("---")
@@ -218,7 +222,7 @@ def main() -> None:
         }
         ComplaintStore().add_complaint(details)
         with st.spinner("Analyzing..."):
-            analysis = analyzer.analyze(details, guideline)
+            analysis = analyzer.analyze(details, guideline, user_directives)
         out_dir = Path("reports")
         out_dir.mkdir(parents=True, exist_ok=True)
         with open(out_dir / "LLM1.txt", "w", encoding="utf-8") as f:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,8 @@ class CLITest(unittest.TestCase):
                     "subject",
                     "--part-code",
                     "code",
+                    "--directives",
+                    "dir",
                 ])
                 output = buf.getvalue()
             llm1 = Path(tmpdir) / "LLM1.txt"
@@ -52,7 +54,16 @@ class CLITest(unittest.TestCase):
         self.assertIn("full_text", output)
         self.assertIn("file.pdf", output)
         mock_manager.return_value.get_format.assert_called_with("A3")
-        mock_analyzer.return_value.analyze.assert_called_once()
+        mock_analyzer.return_value.analyze.assert_called_with(
+            {
+                "complaint": "c",
+                "customer": "cust",
+                "subject": "subject",
+                "part_code": "code",
+            },
+            {"fields": []},
+            "dir",
+        )
         mock_review.return_value.perform.assert_called_with(
             "ok",
             method="A3",

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -58,6 +58,24 @@ class LLMAnalyzerTest(unittest.TestCase):
         self.assertEqual(call_args[0], "")
         self.assertIn("comp", call_args[1])
 
+    @patch.object(LLMAnalyzer, "_query_llm", return_value="ok")
+    def test_directives_added_to_8d_prompt(self, mock_query) -> None:  # type: ignore
+        """Directives should be appended when method is ``8D``."""
+        guideline = {"method": "8D", "fields": []}
+        details = {"complaint": "c", "subject": "s", "part_code": "p"}
+        self.analyzer.analyze(details, guideline, directives="d")
+        call_args = mock_query.call_args[0]
+        self.assertIn("Kullanıcıdan gelen özel talimatlar:\nd", call_args[1])
+
+    @patch.object(LLMAnalyzer, "_query_llm", return_value="ok")
+    def test_directives_added_to_regular_prompt(self, mock_query) -> None:  # type: ignore
+        """Directives should be appended for non-8D methods."""
+        guideline = {"method": "A3", "fields": []}
+        details = {"complaint": "c", "subject": "s", "part_code": "p"}
+        self.analyzer.analyze(details, guideline, directives="d")
+        call_args = mock_query.call_args[0]
+        self.assertIn("Kullanıcıdan gelen özel talimatlar:\nd", call_args[1])
+
     def test_query_llm_fallback(self) -> None:
         """``_query_llm`` should return a placeholder for non-auth errors."""
         mock_openai = types.ModuleType("openai")

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -87,7 +87,16 @@ class StreamlitAppTest(unittest.TestCase):
             m_open.assert_any_call(Path("reports") / "LLM2.txt", "w", encoding="utf-8")
 
             mock_manager.return_value.get_format.assert_called_with("A3")
-            mock_analyzer.return_value.analyze.assert_called_once()
+            mock_analyzer.return_value.analyze.assert_called_with(
+                {
+                    "complaint": "c",
+                    "customer": "cust",
+                    "subject": "subject",
+                    "part_code": "code",
+                },
+                {"fields": []},
+                "c",
+            )
             mock_review.return_value.perform.assert_called_with(
                 "ok",
                 method="A3",


### PR DESCRIPTION
## Summary
- allow passing custom user directives in Streamlit and CLI
- update `LLMAnalyzer.analyze` to append directives to prompts
- handle directives via CLI flag and Streamlit text area
- extend tests for directives across analyzer, streamlit app and cli

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d41db4d44832fa05c715a090b6421