### PR TITLE
Improve UI dropdown for complaint fields

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -150,20 +150,36 @@ def main() -> None:
     method = col1.selectbox("Method", METHODS, key="method")
 
     col2.markdown("### Meta")
-    customer = col2.text_input(
+
+    def select_or_input(label: str, options: list[str], key: str) -> str:
+        choice = col2.selectbox(
+            label,
+            options + ["Yeni değer gir..."],
+            key=f"{key}_select",
+        )
+        if choice == "Yeni değer gir...":
+            return col2.text_input(label, key=key)
+        return choice
+
+    searcher = ExcelClaimsSearcher()
+    customers = searcher.unique_values("customer")
+    subjects = searcher.unique_values("subject")
+    part_codes = searcher.unique_values("part_code")
+
+    customer = select_or_input(
         "Customer",
-        help="Name of the customer submitting the complaint",
-        key="customer",
+        customers,
+        "customer",
     )
-    subject = col2.text_input(
+    subject = select_or_input(
         "Subject",
-        help="Main topic or category of the complaint",
-        key="subject",
+        subjects,
+        "subject",
     )
-    part_code = col2.text_input(
+    part_code = select_or_input(
         "Part code",
-        help="Identifier of the affected part or product",
-        key="part_code",
+        part_codes,
+        "part_code",
     )
     user_directives = st.text_area(
         "Ek özel talimatlar/uyarılar",

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -69,6 +69,21 @@ class ExcelClaimsSearchTest(unittest.TestCase):
             self.assertIn("customer", result[0])
             self.assertEqual(result[0]["customer"], "ACME")
 
+    def test_unique_values(self) -> None:
+        """``unique_values`` should return sorted distinct entries."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "claims.xlsx")
+            self._create_file(file_path)
+
+            wb = load_workbook(file_path)
+            ws = wb.active
+            ws.append(["extra", "ACME", "engine", "X1", datetime(2024, 1, 1)])
+            wb.save(file_path)
+
+            searcher = ExcelClaimsSearcher(file_path)
+            customers = searcher.unique_values("customer")
+            self.assertEqual(customers, ["ACME", "BETA"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -16,7 +16,9 @@ class StreamlitAppTest(unittest.TestCase):
         dummy_st.title = MagicMock()
         dummy_st.set_page_config = MagicMock()
         dummy_st.text_area = MagicMock(return_value="c")
-        dummy_st.selectbox = MagicMock(side_effect=["A3", "Tümü"])
+        dummy_st.selectbox = MagicMock(
+            side_effect=["A3", "Yeni değer gir...", "Yeni değer gir...", "Yeni değer gir...", "Tümü"]
+        )
         dummy_st.text_input = MagicMock(side_effect=["cust", "subject", "code"])
         dummy_st.button = MagicMock(return_value=True)
         dummy_st.checkbox = MagicMock(return_value=False)
@@ -74,6 +76,11 @@ class StreamlitAppTest(unittest.TestCase):
                 "excel": "file.xlsx",
             }
             mock_claims.return_value.search.return_value = []
+            mock_claims.return_value.unique_values.side_effect = [
+                ["cust"],
+                ["subject"],
+                ["code"],
+            ]
 
             module.main()
 
@@ -126,7 +133,9 @@ class StreamlitSearchTest(unittest.TestCase):
         dummy_st.title = MagicMock()
         dummy_st.set_page_config = MagicMock()
         dummy_st.text_area = MagicMock(return_value="")
-        dummy_st.selectbox = MagicMock(side_effect=["A3", "Tümü"])
+        dummy_st.selectbox = MagicMock(
+            side_effect=["A3", "Yeni değer gir...", "Yeni değer gir...", "Yeni değer gir...", "Tümü"]
+        )
         dummy_st.text_input = MagicMock(side_effect=["c", "s", "p"])
         dummy_st.button = MagicMock(side_effect=[query_button, False])
         dummy_st.checkbox = MagicMock(return_value=False)
@@ -192,6 +201,7 @@ class StreamlitSearchTest(unittest.TestCase):
         importlib.reload(module)
         with patch.object(module, "ExcelClaimsSearcher") as mock_searcher:
             mock_searcher.return_value.search.return_value = []
+            mock_searcher.return_value.unique_values.side_effect = [[], [], []]
             module.main()
             self.assertTrue(self.spinner.called)
             calls = dummy_st.markdown.call_args_list
@@ -204,6 +214,7 @@ class StreamlitSearchTest(unittest.TestCase):
         importlib.reload(module)
         with patch.object(module, "ExcelClaimsSearcher") as mock_searcher:
             mock_searcher.return_value.search.return_value = [record]
+            mock_searcher.return_value.unique_values.side_effect = [[], [], []]
             module.main()
             self.assertTrue(self.spinner.called)
             html_calls = [str(c.args[0]) for c in dummy_st.markdown.call_args_list]


### PR DESCRIPTION
## Summary
- extend `ExcelClaimsSearcher` with a `unique_values` helper that returns unique values for a column
- populate dropdowns for customer, subject and part code using unique values
- update unit tests for new behaviour

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d51304d9c832f93ec583810824c7c