### PR TITLE
Add placeholders for dropdown selections

### DIFF
--- a/UI/streamlit_app.py
+++ b/UI/streamlit_app.py
@@ -88,6 +88,7 @@ st.markdown(
 )
 
 METHODS = ["8D", "5N1K", "A3", "DMAIC", "Ishikawa"]
+PLACEHOLDER = "Lütfen seçiniz"
 
 
 def place_logo() -> None:
@@ -154,9 +155,11 @@ def main() -> None:
     def select_or_input(label: str, options: list[str], key: str) -> str:
         choice = col2.selectbox(
             label,
-            options + ["Yeni değer gir..."],
+            [PLACEHOLDER] + options + ["Yeni değer gir..."],
             key=f"{key}_select",
         )
+        if choice == PLACEHOLDER:
+            return ""
         if choice == "Yeni değer gir...":
             return col2.text_input(label, key=key)
         return choice
@@ -232,6 +235,12 @@ def main() -> None:
                 st.markdown(card, unsafe_allow_html=True)
 
     if st.button("🧠 Analyze"):
+        if not all([customer, subject, part_code]):
+            st.error(
+                "Lütfen müşteri, konu ve parça kodu seçimlerini yapınız."
+            )
+            return
+
         manager = GuideManager()
         guideline = manager.get_format(method)
 


### PR DESCRIPTION
## Summary
- add placeholder constant for Streamlit dropdowns
- treat placeholder as empty selection when no customer, subject or part code picked
- block analysis until all dropdown selections are made
- update UI tests for new placeholder and validation

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d53761ca8832fa1fe733cf353aa4b