### PR TITLE
Add env configuration helper and path variable support

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from pathlib import Path
 from datetime import datetime
+import os
 
 from difflib import SequenceMatcher
 from openpyxl import load_workbook
@@ -15,7 +16,14 @@ from . import normalize_text
 class ExcelClaimsSearcher:
     """Search complaint records stored in an Excel file."""
 
-    def __init__(self, path: str | Path = "CC/claims.xlsx") -> None:
+    def __init__(self, path: str | Path | None = None) -> None:
+        """Initialize with optional Excel file ``path``.
+
+        When ``path`` is ``None``, ``CLAIMS_FILE_PATH`` environment variable is
+        consulted. If the variable is unset, ``CC/claims.xlsx`` is used.
+        """
+        if path is None:
+            path = os.getenv("CLAIMS_FILE_PATH", "CC/claims.xlsx")
         self.path = Path(path)
 
     def search(self, filters: Dict[str, str], year: int | None = None) -> List[Dict[str, Any]]:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ varsa otomatik olarak yuklenir:
 export OPENAI_API_KEY="sk-..."
 ```
 
+Anahtari ve sikayet kaydi Excel dosyasinin yolunu kolayca tanimlamak icin
+`configure_env.py` betigini calistirabilirsiniz. Betik istenen bilgileri
+sorarak `.env` dosyasina yazar.
+
+```bash
+python configure_env.py
+```
+
+Bu islemin ardindan `CLAIMS_FILE_PATH` degiskeni de `.env` dosyaniza eklenmis
+olur ve uygulama muster sikayetlerini bu dosyadan okur.
+
 Gecerli bir anahtar saglanmadiginda veya baglanti kurulamazsa analiz
 sonuclari icin yer tutucu metinler dondurulur.
 

--- a/configure_env.py
+++ b/configure_env.py
@@ -1,0 +1,24 @@
+"""Interactive helper to create or update the `.env` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from dotenv import set_key
+
+
+ENV_PATH = Path(".env")
+
+
+def main() -> None:
+    """Prompt for configuration values and store them in ``.env``."""
+    api_key = input("OpenAI API key: ").strip()
+    claims_path = input("Path to claims.xlsx: ").strip()
+
+    ENV_PATH.touch(exist_ok=True)
+    set_key(str(ENV_PATH), "OPENAI_API_KEY", api_key)
+    set_key(str(ENV_PATH), "CLAIMS_FILE_PATH", claims_path)
+    print(f"Configuration written to {ENV_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 from datetime import datetime
+from unittest.mock import patch
 
 from ComplaintSearch.claims_excel import ExcelClaimsSearcher
 from openpyxl import Workbook, load_workbook
@@ -83,6 +84,16 @@ class ExcelClaimsSearchTest(unittest.TestCase):
             searcher = ExcelClaimsSearcher(file_path)
             customers = searcher.unique_values("customer")
             self.assertEqual(customers, ["ACME", "BETA"])
+
+    def test_env_default_path(self) -> None:
+        """File path should come from ``CLAIMS_FILE_PATH`` when not provided."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "claims.xlsx")
+            self._create_file(file_path)
+            with patch.dict("os.environ", {"CLAIMS_FILE_PATH": file_path}):
+                searcher = ExcelClaimsSearcher()
+                result = searcher.search({"customer": "ACME"}, year=2023)
+                self.assertEqual(len(result), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `ExcelClaimsSearcher` read the claims file path from `CLAIMS_FILE_PATH`
- add a `configure_env.py` script to set `OPENAI_API_KEY` and `CLAIMS_FILE_PATH`
- document configuration script in README
- test that `CLAIMS_FILE_PATH` is used when no path is provided

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d59b2e500832fb8aefd7947e71219