### PR TITLE
Add OpenAI model selection and dotenv loading

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from datetime import datetime
 import os
 
+from dotenv import load_dotenv
+
 from difflib import SequenceMatcher
 from openpyxl import load_workbook
 
@@ -19,10 +21,11 @@ class ExcelClaimsSearcher:
     def __init__(self, path: str | Path | None = None) -> None:
         """Initialize with optional Excel file ``path``.
 
-        When ``path`` is ``None``, ``CLAIMS_FILE_PATH`` environment variable is
-        consulted. If the variable is unset, ``CC/claims.xlsx`` is used.
+        When ``path`` is ``None``, ``CLAIMS_FILE_PATH`` is read from the
+        ``.env`` file. If the variable is unset, ``CC/claims.xlsx`` is used.
         """
         if path is None:
+            load_dotenv()
             path = os.getenv("CLAIMS_FILE_PATH", "CC/claims.xlsx")
         self.path = Path(path)
 

--- a/configure_env.py
+++ b/configure_env.py
@@ -13,10 +13,21 @@ def main() -> None:
     """Prompt for configuration values and store them in ``.env``."""
     api_key = input("OpenAI API key: ").strip()
     claims_path = input("Path to claims.xlsx: ").strip()
+    model_choice = input(
+        "OpenAI Model (1: gpt-4o, 2: gpt-4o-mini, 3: gpt-4-turbo, 4: gpt-3.5-turbo): "
+    ).strip()
+    models = {
+        "1": "gpt-4o",
+        "2": "gpt-4o-mini",
+        "3": "gpt-4-turbo",
+        "4": "gpt-3.5-turbo",
+    }
+    model_name = models.get(model_choice, "gpt-4o")
 
     ENV_PATH.touch(exist_ok=True)
     set_key(str(ENV_PATH), "OPENAI_API_KEY", api_key)
     set_key(str(ENV_PATH), "CLAIMS_FILE_PATH", claims_path)
+    set_key(str(ENV_PATH), "OPENAI_MODEL", model_name)
     print(f"Configuration written to {ENV_PATH}")
 
 

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -3,7 +3,9 @@ import tempfile
 import unittest
 from datetime import datetime
 from unittest.mock import patch
+from pathlib import Path
 
+from ComplaintSearch import claims_excel
 from ComplaintSearch.claims_excel import ExcelClaimsSearcher
 from openpyxl import Workbook, load_workbook
 
@@ -94,6 +96,14 @@ class ExcelClaimsSearchTest(unittest.TestCase):
                 searcher = ExcelClaimsSearcher()
                 result = searcher.search({"customer": "ACME"}, year=2023)
                 self.assertEqual(len(result), 1)
+
+    def test_load_dotenv_called(self) -> None:
+        """``load_dotenv`` should be invoked when ``path`` is ``None``."""
+        with patch.dict("os.environ", {"CLAIMS_FILE_PATH": "f"}):
+            with patch.object(claims_excel, "load_dotenv") as mock_load:
+                searcher = ExcelClaimsSearcher()
+                self.assertTrue(mock_load.called)
+                self.assertEqual(searcher.path, Path("f"))
 
 
 if __name__ == "__main__":

--- a/tests/test_configure_env.py
+++ b/tests/test_configure_env.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from dotenv import dotenv_values
+import configure_env
+
+
+class ConfigureEnvTest(unittest.TestCase):
+    """Tests for the ``configure_env`` helper."""
+
+    def test_model_saved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            with patch.object(configure_env, "ENV_PATH", env_path):
+                with patch(
+                    "builtins.input", side_effect=["k", "c.xlsx", "2"],
+                ):
+                    configure_env.main()
+                    data = dotenv_values(env_path)
+            self.assertEqual(data.get("OPENAI_MODEL"), "gpt-4o-mini")
+            self.assertEqual(data.get("OPENAI_API_KEY"), "k")
+            self.assertEqual(data.get("CLAIMS_FILE_PATH"), "c.xlsx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `configure_env.py` to prompt for model choice and store `OPENAI_MODEL`
- load `.env` in `ExcelClaimsSearcher` when path not provided
- add new tests for environment configuration and dotenv loading

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685d5b4722dc832fa82ea5da86976f5e