### PR TITLE
Add FastAPI API with endpoints and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,47 @@ from UI import run_streamlit
 run_streamlit()
 ```
 
+## API Sunucusu
+
+`api` paketindeki FastAPI uygulamasi HTTP uzerinden ayni
+islevlere erisim saglar. Sunucuyu calistirmak icin once bagimliliklari
+kurun ve `run_api.py` dosyasini calistirin:
+
+```bash
+pip install -r requirements.txt
+python run_api.py
+```
+
+Sunucu varsayilan olarak `http://localhost:8000` adresinde
+asagidaki uclari sunar:
+
+- `POST /analyze` – `LLMAnalyzer.analyze` cagrisi
+- `POST /review` – `Review.perform` cagrisi
+- `POST /report` – `ReportGenerator.generate` cagrisi
+- `GET /complaints` – `ComplaintStore` ve `ExcelClaimsSearcher` sorgulari
+
+Ornek kullanim:
+
+```bash
+curl -X POST http://localhost:8000/analyze \
+     -H 'Content-Type: application/json' \
+     -d '{"details": {"complaint": "test"}, "guideline": {"fields": []}}'
+```
+
+### React Arayuzu
+
+API'yi kullanmak icin `frontend/` klasorundeki React projesini
+gelistirme modunda baslatabilirsiniz:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+Bu komut gelistirme sunucusunu calistirir ve API'ye 8000 portundan
+baglanarak istek gonderir.
+
 ## Minimal Ornek
 
 Asagidaki kod ornegi girdi akisini nasil kullanabileceginizi gosterir:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ openai
 streamlit>=1.0
 python-dotenv
 streamlit-option-menu
+
+fastapi
+uvicorn

--- a/run_api.py
+++ b/run_api.py
@@ -1,0 +1,18 @@
+"""Entry point to launch the FastAPI API server."""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+import uvicorn
+
+from api import app
+
+
+def main() -> None:
+    """Start the API server."""
+    load_dotenv()
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import api
+
+
+class APITest(unittest.TestCase):
+    """Tests for FastAPI endpoints."""
+
+    def setUp(self) -> None:
+        self.client = TestClient(api.app)
+
+    def test_analyze_endpoint(self) -> None:
+        payload = {"details": {"complaint": "c"}, "guideline": {"fields": []}, "directives": ""}
+        with patch.object(api.analyzer, "analyze", return_value={"ok": 1}) as mock_analyze:
+            response = self.client.post("/analyze", json=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ok": 1})
+        mock_analyze.assert_called_with(payload["details"], payload["guideline"], "")
+
+    def test_review_endpoint(self) -> None:
+        body = {"text": "t", "context": {"a": "b"}}
+        with patch.object(api.reviewer, "perform", return_value="r") as mock_perf:
+            response = self.client.post("/review", json=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"result": "r"})
+        mock_perf.assert_called_with("t", a="b")
+
+    def test_report_endpoint(self) -> None:
+        body = {"analysis": {}, "complaint_info": {}, "output_dir": "."}
+        with patch.object(api.reporter, "generate", return_value={"pdf": "p", "excel": "e"}) as mock_gen:
+            response = self.client.post("/report", json=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"pdf": "p", "excel": "e"})
+        mock_gen.assert_called_with({}, {}, ".")
+
+    def test_complaints_endpoint(self) -> None:
+        with patch.object(api._store, "search", return_value=[{"id": 1}]) as mock_store, \
+             patch.object(api._excel_searcher, "search", return_value=[{"id": 2}]) as mock_excel:
+            response = self.client.get("/complaints", params={"keyword": "k", "customer": "c"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"store": [{"id": 1}], "excel": [{"id": 2}]})
+        mock_store.assert_called_with("k")
+        mock_excel.assert_called_with({"customer": "c"}, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -1,0 +1,19 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class RunAPITest(unittest.TestCase):
+    """Tests for the ``run_api`` entry point."""
+
+    def test_main_invokes_uvicorn(self) -> None:
+        module = importlib.import_module("run_api")
+        with patch.object(module, "load_dotenv") as mock_load, \
+             patch.object(module, "uvicorn") as mock_uvicorn:
+            module.main()
+            mock_load.assert_called_once()
+            mock_uvicorn.run.assert_called_once_with(module.app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `api/` FastAPI server exposing analysis, review, report and complaint queries
- create `run_api.py` entry point to launch the server
- document API usage and React frontend in README
- include FastAPI and uvicorn in requirements
- test API routes and entry point

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685db194f060832fa201bf3f13fecbc8