### PR TITLE
Fix streamlit path for PyInstaller builds

### DIFF
--- a/UI/__init__.py
+++ b/UI/__init__.py
@@ -16,7 +16,18 @@ def run_streamlit() -> None:
     script = Path(streamlit_app.__file__).resolve()
     frozen = getattr(sys, "frozen", False)
 
-    if frozen or not script.exists():
+    if frozen:
+        bundle_root = Path(getattr(sys, "_MEIPASS", Path.cwd()))
+        candidate = bundle_root / "UI" / "streamlit_app.py"
+        if candidate.exists():
+            script = candidate
+        else:
+            tmp_path = Path(tempfile.gettempdir()) / "streamlit_app.py"
+            with resources.files("UI").joinpath("streamlit_app.py").open("rb") as src, \
+                    open(tmp_path, "wb") as dst:
+                dst.write(src.read())
+            script = tmp_path
+    elif not script.exists():
         tmp_path = Path(tempfile.gettempdir()) / "streamlit_app.py"
         with resources.files("UI").joinpath("streamlit_app.py").open("rb") as src, \
                 open(tmp_path, "wb") as dst:


### PR DESCRIPTION
## Summary
- ensure `run_streamlit` checks the PyInstaller bundle for `streamlit_app.py`
- add regression test for `_MEIPASS` handling

## Testing
- `python -m unittest tests.test_ui`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_685e417beea0832f8428be622b929d1c