### PR TITLE
Add frontend analysis form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Fonts/*.pkl
 # Frontend
 frontend/node_modules/
 frontend/dist/
+complaints.json

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/material": "^7.1.2",
+        "@mui/x-date-pickers": "^8.6.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1385,6 +1386,94 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.6.0.tgz",
+      "integrity": "sha512-zZsyEJrmC2zv9noQGTLpjsKmbHxiaO0exKwQgvn/CbCIl6Dqlo6E6l+R3V5uB93u5mUK3yLsVHzeLWARLZBC9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.1.1",
+        "@mui/x-internals": "8.6.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.6.0.tgz",
+      "integrity": "sha512-ed6IOmnUpm18b607JRTJS+xya731CrQtJKX35l/4TlH8Df1SpkSJsmoyBBmZ09DNX8YNEFpYt5EyfXI28iyM2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "@mui/utils": "^7.1.1",
+        "reselect": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3095,6 +3184,12 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/material": "^7.1.2",
+    "@mui/x-date-pickers": "^8.6.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import Box from '@mui/material/Box'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import Autocomplete from '@mui/material/Autocomplete'
+import Alert from '@mui/material/Alert'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { DatePicker } from '@mui/x-date-pickers/DatePicker'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+
+function AnalysisForm() {
+  const [complaint, setComplaint] = useState('')
+  const [guideline, setGuideline] = useState(null)
+  const [date, setDate] = useState(null)
+  const [error, setError] = useState('')
+  const [results, setResults] = useState(null)
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!complaint || !guideline || !date) {
+      setError('All fields are required.')
+      return
+    }
+    setError('')
+    setResults(null)
+    const payload = {
+      details: { complaint, date: date.toISOString() },
+      guideline: { method: guideline },
+      directives: ''
+    }
+    try {
+      const response = await fetch('/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      const data = await response.json()
+      setResults(data)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const rows = results ? Object.entries(results) : []
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 2 }}>
+        <TextField
+          label="Complaint"
+          value={complaint}
+          onChange={(e) => setComplaint(e.target.value)}
+          fullWidth
+          margin="normal"
+          helperText="Enter complaint details"
+        />
+        <Autocomplete
+          options={['8D', 'QR', 'Other']}
+          value={guideline}
+          onChange={(event, newValue) => setGuideline(newValue)}
+          renderInput={(params) => (
+            <TextField {...params} label="Guideline" margin="normal" helperText="Select analysis guideline" />
+          )}
+        />
+        <DatePicker
+          label="Date"
+          value={date}
+          onChange={(newValue) => setDate(newValue)}
+          renderInput={(params) => <TextField {...params} margin="normal" helperText="Choose report date" />}
+        />
+        <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+          Analyze
+        </Button>
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {rows.length > 0 && (
+          <Table sx={{ mt: 2 }} size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Key</TableCell>
+                <TableCell>Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map(([key, value]) => (
+                <TableRow key={key}>
+                  <TableCell>{key}</TableCell>
+                  <TableCell>{String(value)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Box>
+    </LocalizationProvider>
+  )
+}
+
+export default AnalysisForm

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
-import SampleForm from '../components/SampleForm'
+import AnalysisForm from '../components/AnalysisForm'
 import ComplaintFetcher from '../components/ComplaintFetcher'
 
 function Home() {
@@ -9,7 +9,7 @@ function Home() {
       <Typography variant="h4" component="h1" gutterBottom>
         Plasma QR Home
       </Typography>
-      <SampleForm />
+      <AnalysisForm />
       <ComplaintFetcher />
     </Container>
   )


### PR DESCRIPTION
## Summary
- add Material UI date picker dependency
- implement `AnalysisForm` using Material UI components
- show form on homepage instead of the sample form
- ignore generated `complaints.json`

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_685e53caeaf8832fb35b816bafd0ee4a