### PR TITLE
Add API routes for options, guide, and complaint persistence

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -87,4 +87,30 @@ def complaints(
     return {"store": store_results, "excel": excel_results}
 
 
+class ComplaintBody(BaseModel):
+    complaint: str
+    customer: str
+    subject: str
+    part_code: str
+
+
+@app.post("/complaints")
+def add_complaint(body: ComplaintBody) -> Dict[str, str]:
+    """Persist a complaint in the JSON store."""
+    _store.add_complaint(body.dict())
+    return {"status": "ok"}
+
+
+@app.get("/options/{field}")
+def options(field: str) -> Dict[str, Any]:
+    """Return unique option values for ``field`` from the Excel claims file."""
+    return {"values": _excel_searcher.unique_values(field)}
+
+
+@app.get("/guide/{method}")
+def guide(method: str) -> Dict[str, Any]:
+    """Return guideline data for ``method``."""
+    return _guide_manager.get_format(method)
+
+
 __all__ = ["app"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,28 @@ class APITest(unittest.TestCase):
         mock_store.assert_called_with("k")
         mock_excel.assert_called_with({"customer": "c"}, None)
 
+    def test_options_endpoint(self) -> None:
+        with patch.object(api._excel_searcher, "unique_values", return_value=["a", "b"]) as mock_opts:
+            response = self.client.get("/options/customer")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"values": ["a", "b"]})
+        mock_opts.assert_called_with("customer")
+
+    def test_guide_endpoint(self) -> None:
+        with patch.object(api._guide_manager, "get_format", return_value={"method": "8D"}) as mock_get:
+            response = self.client.get("/guide/8D")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"method": "8D"})
+        mock_get.assert_called_with("8D")
+
+    def test_add_complaint_endpoint(self) -> None:
+        body = {"complaint": "c", "customer": "cust", "subject": "s", "part_code": "p"}
+        with patch.object(api._store, "add_complaint") as mock_add:
+            response = self.client.post("/complaints", json=body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+        mock_add.assert_called_with(body)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support persisting complaints through `/complaints` POST
- expose unique Excel options via `/options/{field}`
- provide guideline data at `/guide/{method}`
- test new API routes

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_685eacb6d63c832fb2ed029e51faa17a