### PR TITLE
Pin FastAPI dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,8 @@ streamlit>=1.0
 python-dotenv
 streamlit-option-menu
 
-fastapi
+# Web server and client libraries
+fastapi==0.111.0
+starlette==0.36.3
+httpx==0.27.*
 uvicorn

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,10 @@ install_requires =
     openai
     streamlit>=1.0
     python-dotenv
+    streamlit-option-menu
+
+    # Web server and client libraries
+    fastapi==0.111.0
+    starlette==0.36.3
+    httpx==0.27.*
+    uvicorn


### PR DESCRIPTION
## Summary
- pin FastAPI, Starlette and httpx versions
- sync `setup.cfg` with `requirements.txt`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685eadd391ac832f8d91578dfde5ac4d