### PR TITLE
Fix API calls in React

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -5,6 +5,7 @@ import Button from '@mui/material/Button'
 import Autocomplete from '@mui/material/Autocomplete'
 import Alert from '@mui/material/Alert'
 import Typography from '@mui/material/Typography'
+import { API_BASE } from '../api'
 
 const METHODS = ['8D', 'A3', 'Ishikawa', '5N1K', 'DMAIC']
 
@@ -44,7 +45,7 @@ function AnalysisForm() {
     try {
       const details = { complaint, customer, subject, part_code: partCode }
       const analyzeBody = { details, guideline: { method }, directives }
-      const analyzeRes = await fetch('/analyze', {
+      const analyzeRes = await fetch(`${API_BASE}/analyze`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(analyzeBody)
@@ -53,7 +54,7 @@ function AnalysisForm() {
         throw new Error(`HTTP ${analyzeRes.status}`)
       }
       const analysis = await analyzeRes.json()
-      const reviewRes = await fetch('/review', {
+      const reviewRes = await fetch(`${API_BASE}/review`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: JSON.stringify(analysis), context: { method } })
@@ -63,7 +64,7 @@ function AnalysisForm() {
       }
       const { result } = await reviewRes.json()
       analysis.full_report = { response: result }
-      const reportRes = await fetch('/report', {
+      const reportRes = await fetch(`${API_BASE}/report`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/components/ComplaintFetcher.jsx
+++ b/frontend/src/components/ComplaintFetcher.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
+import { API_BASE } from '../api'
 
 function ComplaintFetcher() {
   const [data, setData] = useState(null)
@@ -9,7 +10,7 @@ function ComplaintFetcher() {
 
   const fetchData = async () => {
     try {
-      const response = await fetch('/complaints')
+      const response = await fetch(`${API_BASE}/complaints`)
       if (!response.ok) {
         throw new Error(`HTTP error ${response.status}`)
       }

--- a/frontend/src/components/ComplaintQuery.jsx
+++ b/frontend/src/components/ComplaintQuery.jsx
@@ -12,6 +12,7 @@ import TableCell from '@mui/material/TableCell'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Alert from '@mui/material/Alert'
+import { API_BASE } from '../api'
 
 function ComplaintQuery() {
   const [complaint, setComplaint] = useState('')
@@ -34,7 +35,7 @@ function ComplaintQuery() {
     if (usePartCode && partCode) params.append('part_code', partCode)
     if (year) params.append('year', year)
     try {
-      const res = await fetch(`/complaints?${params.toString()}`)
+      const res = await fetch(`${API_BASE}/complaints?${params.toString()}`)
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`)
       }


### PR DESCRIPTION
## Summary
- use an API base URL constant for frontend requests
- update form components to call the FastAPI service directly

## Testing
- `npm test`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_685efd91dcb4832f93034b4f153ff6e2