### PR TITLE
Enable CORS in API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from GuideManager import GuideManager
@@ -14,6 +15,12 @@ from ReportGenerator import ReportGenerator
 from ComplaintSearch import ComplaintStore, ExcelClaimsSearcher
 
 app = FastAPI(title="Plasma QR API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Shared component instances
 _guide_manager = GuideManager()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,18 @@ class APITest(unittest.TestCase):
     def setUp(self) -> None:
         self.client = TestClient(api.app, raise_server_exceptions=False)
 
+    def test_cors_preflight(self) -> None:
+        """OPTIONS request should include CORS headers."""
+        response = self.client.options(
+            "/analyze",
+            headers={
+                "Origin": "http://example.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        self.assertIn(response.status_code, {200, 204})
+        self.assertIn("access-control-allow-origin", response.headers)
+
     def test_analyze_endpoint(self) -> None:
         payload = {"details": {"complaint": "c"}, "guideline": {"fields": []}, "directives": ""}
         with patch.object(api.analyzer, "analyze", return_value={"ok": 1}) as mock_analyze:


### PR DESCRIPTION
## Summary
- expose FastAPI app with CORS middleware
- test that OPTIONS requests return CORS headers

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685f0993f924832f89d3efd7c67df43d