### PR TITLE
Improve theme with fonts and cards

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,19 @@ function App() {
   }
 
   const theme = useMemo(
-    () => createTheme({ palette: { mode } }),
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          primary: {
+            main: mode === 'light' ? '#0d47a1' : '#90caf9'
+          }
+        },
+        shape: { borderRadius: 12 },
+        typography: {
+          fontFamily: "'Inter','Roboto','Helvetica','Arial',sans-serif"
+        }
+      }),
     [mode]
   )
 

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -5,6 +5,8 @@ import Button from '@mui/material/Button'
 import Autocomplete from '@mui/material/Autocomplete'
 import Alert from '@mui/material/Alert'
 import Typography from '@mui/material/Typography'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
 import { API_BASE } from '../api'
 
 const METHODS = ['8D', 'A3', 'Ishikawa', '5N1K', 'DMAIC']
@@ -85,7 +87,9 @@ function AnalysisForm() {
   }
 
   return (
-    <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 2 }}>
+    <Card sx={{ mt: 2 }}>
+      <CardContent>
+        <Box component="form" onSubmit={handleSubmit} noValidate>
       <TextField
         label="Complaint"
         value={complaint}
@@ -161,7 +165,9 @@ function AnalysisForm() {
           )}
         </Box>
       )}
-    </Box>
+        </Box>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Roboto', Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #1a1a1a;
+  background-color: #f5f7fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- load Inter and Roboto webfonts in `index.html`
- set global font and background in `index.css`
- create MUI theme with blue palette, rounded corners, and new typography
- wrap `AnalysisForm` in `Card` and `CardContent`

## Testing
- `python -m unittest discover`
- `npm run lint` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685f0dd052c4832f9230485f8cb07be4