### PR TITLE
Add loading and Snackbar notifications

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -33,6 +33,7 @@ test('submits form and shows results', async () => {
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
   await screen.findByText(/done/)
+  await screen.findByText(/created successfully/i)
 })
 
 test('shows error on api failure', async () => {
@@ -48,4 +49,5 @@ test('shows error on api failure', async () => {
 
   await waitFor(() => expect(fetch).toHaveBeenCalled())
   await screen.findByText(/http 500/i)
+  expect(screen.getByText(/http 500/i)).toBeInTheDocument()
 })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -4,6 +4,8 @@ import TextField from '@mui/material/TextField'
 import Button from '@mui/material/Button'
 import Autocomplete from '@mui/material/Autocomplete'
 import Alert from '@mui/material/Alert'
+import Snackbar from '@mui/material/Snackbar'
+import CircularProgress from '@mui/material/CircularProgress'
 import Typography from '@mui/material/Typography'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -32,6 +34,8 @@ function AnalysisForm() {
   const [method, setMethod] = useState(null)
   const [directives, setDirectives] = useState('')
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [loading, setLoading] = useState(false)
   const [finalText, setFinalText] = useState('')
   const [downloads, setDownloads] = useState(null)
 
@@ -42,6 +46,8 @@ function AnalysisForm() {
       return
     }
     setError('')
+    setSuccess('')
+    setLoading(true)
     setFinalText('')
     setDownloads(null)
     try {
@@ -81,8 +87,11 @@ function AnalysisForm() {
       const downloadsData = await reportRes.json()
       setFinalText(result)
       setDownloads(downloadsData)
+      setSuccess('Report created successfully.')
     } catch (err) {
       setError(err.message)
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -141,11 +150,21 @@ function AnalysisForm() {
       <Button type="submit" variant="contained" sx={{ mt: 2 }}>
         Analyze
       </Button>
-      {error && (
-        <Alert severity="error" sx={{ mt: 2 }}>
-          {error}
-        </Alert>
+      {loading && (
+        <CircularProgress sx={{ mt: 2 }} data-testid="loading-indicator" />
       )}
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={6000}
+        onClose={() => setError('')}
+        message={error}
+      />
+      <Snackbar
+        open={Boolean(success)}
+        autoHideDuration={6000}
+        onClose={() => setSuccess('')}
+        message={success}
+      />
       {finalText && (
         <Box sx={{ mt: 2 }}>
           <Typography variant="h6">Final Report</Typography>


### PR DESCRIPTION
## Summary
- show a progress spinner when submitting the analysis form
- use Snackbar to display success and error messages
- notify user when report creation succeeds
- update tests for new Snackbar behavior

## Testing
- `python -m unittest discover`
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_b_685f0f516d54832fb560a1a1012396ff