### PR TITLE
Improve AnalysisForm UX

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -34,6 +34,9 @@ test('submits form and shows results', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
   await screen.findByText(/done/)
   await screen.findByText(/created successfully/i)
+  await screen.findByTestId('CheckCircleIcon')
+  expect(screen.getByTestId('PictureAsPdfIcon')).toBeInTheDocument()
+  expect(screen.getByTestId('FileDownloadIcon')).toBeInTheDocument()
 })
 
 test('shows error on api failure', async () => {

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -9,6 +9,10 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Typography from '@mui/material/Typography'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
+import Grow from '@mui/material/Grow'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
+import FileDownloadIcon from '@mui/icons-material/FileDownload'
 import { API_BASE } from '../api'
 
 const METHODS = ['8D', 'A3', 'Ishikawa', '5N1K', 'DMAIC']
@@ -167,19 +171,40 @@ function AnalysisForm() {
       />
       {finalText && (
         <Box sx={{ mt: 2 }}>
+          <Grow in={Boolean(success)}>
+            <Box display="flex" justifyContent="center" sx={{ mb: 1 }}>
+              <CheckCircleIcon
+                color="success"
+                fontSize="large"
+                data-testid="CheckCircleIcon"
+              />
+            </Box>
+          </Grow>
           <Typography variant="h6">Final Report</Typography>
           <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
             {finalText}
           </Typography>
           {downloads && (
             <Box sx={{ mt: 1 }}>
-              <a href={downloads.pdf} download>
-                Download PDF
-              </a>{' '}
-              |{' '}
-              <a href={downloads.excel} download>
-                Download Excel
-              </a>
+              <Button
+                component="a"
+                href={downloads.pdf}
+                download
+                variant="outlined"
+                startIcon={<PictureAsPdfIcon />}
+                sx={{ mr: 1 }}
+              >
+                PDF
+              </Button>
+              <Button
+                component="a"
+                href={downloads.excel}
+                download
+                variant="outlined"
+                startIcon={<FileDownloadIcon />}
+              >
+                Excel
+              </Button>
             </Box>
           )}
         </Box>


### PR DESCRIPTION
## Summary
- use MUI buttons with download icons instead of anchors
- show a Grow animation with CheckCircle on success
- test for success animation and icons

## Testing
- `npm test --prefix frontend`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_685f10da3364832fb12f47b6a4d622a4