### PR TITLE
Add footer component

### DIFF
--- a/frontend/src/__tests__/Footer.test.jsx
+++ b/frontend/src/__tests__/Footer.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import Footer from '../components/Footer'
+
+it('renders company info and links', () => {
+  render(<Footer />)
+  const year = new Date().getFullYear().toString()
+  expect(screen.getByText(new RegExp(year))).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /about/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /privacy/i })).toBeInTheDocument()
+})

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,51 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Link from '@mui/material/Link'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { useTheme } from '@mui/material/styles'
+
+function Footer() {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+  const year = new Date().getFullYear()
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        mt: 4,
+        py: 3,
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.secondary,
+        borderTop: `1px solid ${theme.palette.divider}`,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: isMobile ? 'column' : 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          maxWidth: 'md',
+          mx: 'auto',
+          px: 2,
+          textAlign: isMobile ? 'center' : 'inherit',
+        }}
+      >
+        <Typography variant="body2" sx={{ mb: isMobile ? 1 : 0 }}>
+          © {year} Plasma QR. All rights reserved.
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Link href="#" color="inherit" underline="hover">
+            About
+          </Link>
+          <Link href="#" color="inherit" underline="hover">
+            Privacy
+          </Link>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default Footer

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,16 +2,20 @@ import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
 import AnalysisForm from '../components/AnalysisForm'
 import ComplaintFetcher from '../components/ComplaintFetcher'
+import Footer from '../components/Footer'
 
 function Home() {
   return (
-    <Container maxWidth="sm">
-      <Typography variant="h4" component="h1" gutterBottom>
-        Plasma QR Home
-      </Typography>
-      <AnalysisForm />
-      <ComplaintFetcher />
-    </Container>
+    <>
+      <Container maxWidth="sm">
+        <Typography variant="h4" component="h1" gutterBottom>
+          Plasma QR Home
+        </Typography>
+        <AnalysisForm />
+        <ComplaintFetcher />
+      </Container>
+      <Footer />
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- add `Footer` component with responsive styling
- show footer on `Home` page
- test rendering of footer

## Testing
- `python -m unittest discover`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685f14db9538832f823fac497e5953e8