### PR TITLE
Refine dashboard styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto:wght@400;500;700&family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,12 +16,15 @@ function App() {
         palette: {
           mode,
           primary: {
-            main: mode === 'light' ? '#0d47a1' : '#90caf9'
+            main: '#002855'
+          },
+          secondary: {
+            main: '#14397c'
           }
         },
         shape: { borderRadius: 12 },
         typography: {
-          fontFamily: "'Inter','Roboto','Helvetica','Arial',sans-serif"
+          fontFamily: "'Poppins','Inter','Roboto','Helvetica','Arial',sans-serif"
         }
       }),
     [mode]

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -140,7 +140,13 @@ function AnalysisForm() {
   }
 
   return (
-    <Card sx={{ mt: 2 }}>
+    <Card
+      sx={{
+        mt: 2,
+        background: 'linear-gradient(180deg, #ffffff 0%, #f0f4fa 100%)',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+      }}
+    >
       <CardContent>
         <Box component="form" onSubmit={handleSubmit} noValidate>
           <Grid container spacing={2}>
@@ -293,7 +299,12 @@ function AnalysisForm() {
         multiline
         minRows={3}
       />
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+      <Button
+        type="submit"
+        variant="contained"
+        startIcon={<QrCode2Icon />}
+        sx={{ mt: 2, px: 4, py: 1.5, fontSize: '1rem', transition: 'transform 0.2s', '&:hover': { transform: 'translateY(-2px)' } }}
+      >
         Analyze
       </Button>
       {loading && (
@@ -334,7 +345,7 @@ function AnalysisForm() {
                 download
                 variant="outlined"
                 startIcon={<PictureAsPdfIcon />}
-                sx={{ mr: 1 }}
+                sx={{ mr: 1, px: 3, py: 1 }}
               >
                 PDF
               </Button>
@@ -344,6 +355,7 @@ function AnalysisForm() {
                 download
                 variant="outlined"
                 startIcon={<FileDownloadIcon />}
+                sx={{ px: 3, py: 1 }}
               >
                 Excel
               </Button>

--- a/frontend/src/components/ComplaintFetcher.jsx
+++ b/frontend/src/components/ComplaintFetcher.jsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import { API_BASE } from '../api'
+import FileDownloadIcon from '@mui/icons-material/FileDownload'
 
 function ComplaintFetcher() {
   const [data, setData] = useState(null)
@@ -23,8 +24,13 @@ function ComplaintFetcher() {
   }
 
   return (
-    <Box sx={{ mt: 2 }}>
-      <Button variant="outlined" onClick={fetchData} sx={{ mb: 2 }}>
+    <Box sx={{ mt: 2, background: 'linear-gradient(180deg,#ffffff,#f0f4fa)', p: 2, borderRadius: 2, boxShadow: '0 4px 12px rgba(0,0,0,0.1)' }}>
+      <Button
+        variant="contained"
+        onClick={fetchData}
+        startIcon={<FileDownloadIcon />}
+        sx={{ mb: 2, px: 3, py: 1.2 }}
+      >
         Fetch Complaints
       </Button>
       {error && (

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -19,23 +19,31 @@ function Header({ toggleColorMode, mode }) {
     <AppBar
       position="static"
       sx={{
-        backgroundColor: theme.palette.background.paper,
-        color: theme.palette.text.primary,
-        boxShadow: theme.shadows[1]
+        backgroundColor: '#002855',
+        color: '#ffffff',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+        borderBottom: '4px solid #14397c'
       }}
     >
       <Toolbar>
         <Box component="img" src={logo} alt="Company Logo" sx={{ height: isMobile ? 40 : 50, mr: 2 }} />
-        <Typography variant={isMobile ? 'h6' : 'h5'} sx={{ flexGrow: 1 }}>
+        <Typography
+          variant={isMobile ? 'h6' : 'h5'}
+          sx={{
+            flexGrow: 1,
+            fontFamily: 'Poppins, Inter, sans-serif',
+            animation: 'fadeIn 1s ease-in-out'
+          }}
+        >
           Plasma QR
         </Typography>
-        <IconButton color="inherit" aria-label="help">
+        <IconButton color="inherit" aria-label="help" sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
           <HelpOutlineIcon />
         </IconButton>
-        <IconButton color="inherit" aria-label="settings">
+        <IconButton color="inherit" aria-label="settings" sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
           <SettingsIcon />
         </IconButton>
-        <IconButton color="inherit" onClick={toggleColorMode} aria-label="toggle color mode">
+        <IconButton color="inherit" onClick={toggleColorMode} aria-label="toggle color mode" sx={{ mx: 0.5, transition: 'transform 0.2s', '&:hover': { transform: 'scale(1.1)' } }}>
           {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
         </IconButton>
       </Toolbar>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: 'Inter', 'Roboto', Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Roboto', 'Poppins', Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
   color: #1a1a1a;
-  background-color: #f5f7fa;
+  background: linear-gradient(135deg, #e8edf5 0%, #ffffff 100%);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -31,25 +31,31 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  font-family: 'Poppins', 'Inter', sans-serif;
+  color: #002855;
 }
 
 button {
   border-radius: 8px;
   border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+  padding: 0.8em 1.6em;
+  font-size: 1.1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #002855;
+  color: #ffffff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #14397c;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(20, 57, 124, 0.5);
 }
 
 @media (prefers-color-scheme: light) {
@@ -61,6 +67,18 @@ button:focus-visible {
     color: #747bff;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #002855;
+    color: #ffffff;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -8,8 +8,13 @@ function Home() {
   return (
     <>
       <Container maxWidth="sm">
-        <Typography variant="h4" component="h1" gutterBottom>
-          Plasma QR Home
+        <Typography
+          variant="h4"
+          component="h1"
+          gutterBottom
+          sx={{ color: '#002855', fontFamily: 'Poppins, Inter, sans-serif' }}
+        >
+          Plasma QR
         </Typography>
         <AnalysisForm />
         <ComplaintFetcher />


### PR DESCRIPTION
## Summary
- apply brand font Poppins in index.html
- use Poppins and gradient background for global CSS
- enhance theme colors in App provider
- update header with stronger branding and icon hover effects
- polish home heading style
- restyle forms, buttons, and complaint fetcher with modern look

## Testing
- `python -m unittest discover` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_b_685f1f0532a0832f8ab3ca197015c265