### PR TITLE
Add year range search functionality

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -78,6 +78,8 @@ def complaints(
     subject: Optional[str] = None,
     part_code: Optional[str] = None,
     year: Optional[int] = None,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Return complaint queries from JSON store and Excel file."""
     store_results = _store.search(keyword) if keyword else []
@@ -90,7 +92,14 @@ def complaints(
         filters["subject"] = subject
     if part_code:
         filters["part_code"] = part_code
-    excel_results = _excel_searcher.search(filters, year) if filters or year else []
+    excel_results = []
+    if filters or year is not None or start_year is not None or end_year is not None:
+        excel_results = _excel_searcher.search(
+            filters,
+            year,
+            start_year=start_year,
+            end_year=end_year,
+        )
     return {"store": store_results, "excel": excel_results}
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,14 @@ class APITest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"store": [{"id": 1}], "excel": [{"id": 2}]})
         mock_store.assert_called_with("k")
-        mock_excel.assert_called_with({"customer": "c"}, None)
+        mock_excel.assert_called_with({"customer": "c"}, None, start_year=None, end_year=None)
+
+    def test_complaints_endpoint_year_range(self) -> None:
+        params = {"customer": "c", "start_year": 2020, "end_year": 2022}
+        with patch.object(api._excel_searcher, "search", return_value=[]) as mock_excel:
+            response = self.client.get("/complaints", params=params)
+        self.assertEqual(response.status_code, 200)
+        mock_excel.assert_called_with({"customer": "c"}, None, start_year=2020, end_year=2022)
 
     def test_options_endpoint(self) -> None:
         with patch.object(api._excel_searcher, "unique_values", return_value=["a", "b"]) as mock_opts:

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -105,6 +105,19 @@ class ExcelClaimsSearchTest(unittest.TestCase):
                 self.assertTrue(mock_load.called)
                 self.assertEqual(searcher.path, Path("f"))
 
+    def test_year_range(self) -> None:
+        """Records should be filterable by a start and end year."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "claims.xlsx")
+            self._create_file(file_path)
+            searcher = ExcelClaimsSearcher(file_path)
+            both = searcher.search({}, start_year=2022, end_year=2023)
+            self.assertEqual(len(both), 2)
+            just_2022 = searcher.search({}, start_year=2022, end_year=2022)
+            self.assertEqual(len(just_2022), 1)
+            overlap = searcher.search({}, year=2023, start_year=2022, end_year=2023)
+            self.assertEqual(len(overlap), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `ExcelClaimsSearcher.search` with `start_year` and `end_year`
- allow `/complaints` endpoint to accept year range parameters
- test year range logic in searcher and API

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_685fd30783fc832fb77ef53986a9efea