### PR TITLE
Expand AnalysisForm inputs on medium screens

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -162,7 +162,7 @@ function AnalysisForm() {
                 sx={inputSx}
               />
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid item xs={12} md={12}>
               <Autocomplete
                 fullWidth
                 freeSolo
@@ -280,7 +280,7 @@ function AnalysisForm() {
                 </Alert>
               )}
             </Grid>
-            <Grid item xs={12} md={6}>
+            <Grid item xs={12} md={12}>
               <TextField
                 label="Directives"
                 value={directives}


### PR DESCRIPTION
## Summary
- give Customer/Subject/Part Code/Method container a full-width grid size
- adjust Directives grid item to also span full width
- run frontend unit tests to ensure behaviour remains intact

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_685fe010e68c832f8b5a207f39674d96