### PR TITLE
Fix form layout for wider inputs

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -150,7 +150,7 @@ function AnalysisForm() {
       <CardContent>
         <Box component="form" onSubmit={handleSubmit} noValidate>
           <Grid container spacing={3} alignItems="stretch">
-            <Grid item xs={12} md={7} sx={{ display: 'flex' }}>
+            <Grid item xs={12} md={7} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
               <TextField
                 label="Complaint"
                 value={complaint}
@@ -158,14 +158,24 @@ function AnalysisForm() {
                 fullWidth
                 margin="normal"
                 multiline
-                minRows={12}
-                sx={{ ...inputSx, width: '100%', flexGrow: 1 }}
+                minRows={14}
+                sx={{ ...inputSx, width: '100%', flexGrow: 1, height: '100%' }}
               />
             </Grid>
-            <Grid item xs={12} md={5} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Grid
+              item
+              xs={12}
+              md={5}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                height: '100%'
+              }}
+            >
               <Autocomplete
                 fullWidth
-                sx={{ width: '100%' }}
+                sx={{ width: '100%', mb: 2 }}
                 freeSolo
                 options={customerOptions}
                 inputValue={customer}
@@ -194,7 +204,7 @@ function AnalysisForm() {
               />
               <Autocomplete
                 fullWidth
-                sx={{ width: '100%' }}
+                sx={{ width: '100%', mb: 2 }}
                 freeSolo
                 options={subjectOptions}
                 inputValue={subject}
@@ -223,7 +233,7 @@ function AnalysisForm() {
               />
               <Autocomplete
                 fullWidth
-                sx={{ width: '100%' }}
+                sx={{ width: '100%', mb: 2 }}
                 freeSolo
                 options={partCodeOptions}
                 inputValue={partCode}
@@ -292,7 +302,7 @@ function AnalysisForm() {
                 fullWidth
                 margin="normal"
                 multiline
-                minRows={6}
+                minRows={7}
                 sx={{ ...inputSx, width: '100%' }}
               />
             </Grid>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -9,9 +9,8 @@ function Home() {
     <>
       <Container
         sx={{
-          width: { xs: '90%', sm: '70%' },
-          maxWidth: 800,
-          minWidth: { sm: 600 },
+          width: '100%',
+          maxWidth: 'none',
           margin: '0 auto',
         }}
       >


### PR DESCRIPTION
## Summary
- widen the Home page container so form can expand
- allow complaint and stacked fields to stretch to full height
- bump complaint and directives text box row counts
- run Python and Vitest suites

## Testing
- `python -m unittest discover -v`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6860276f8ea4832fa99b742664c949ad