### PR TITLE
Fix layout spacing in AnalysisForm

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -169,7 +169,7 @@ function AnalysisForm() {
               sx={{
                 display: 'flex',
                 flexDirection: 'column',
-                justifyContent: 'space-between',
+                gap: 2,
                 height: '100%'
               }}
             >


### PR DESCRIPTION
## Summary
- adjust spacing in AnalysisForm grid so guide text doesn't reposition the layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6860305e295c832fb9f1a5987cfb524d