### PR TITLE
Fix Card height in AnalysisForm

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -145,6 +145,7 @@ function AnalysisForm() {
         width: '100%',
         maxWidth: 'none',
         minWidth: 1100,
+        height: '100%',
         mx: 'auto',
         boxSizing: 'border-box',
         p: 3,


### PR DESCRIPTION
## Summary
- keep the AnalysisForm card at full height
- run unit tests

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6860595f76c8832f8f05c963f6f24a01