### PR TITLE
Add stretch justification to AnalysisForm grid

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -167,6 +167,7 @@ function AnalysisForm() {
             container
             spacing={3}
             alignItems="stretch"
+            justifyContent="stretch"
             sx={{ flexGrow: 1, height: '100%' }}
           >
             <Grid


### PR DESCRIPTION
## Summary
- ensure analysis form grid stretches items by default
- run unit tests for backend and frontend

## Testing
- `python -m unittest discover`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68605a9435b4832fa2615f88665fed4a