### PR TITLE
Add overflow to AnalysisForm multiline fields

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -184,7 +184,7 @@ function AnalysisForm() {
                 margin="normal"
                 multiline
                 minRows={14}
-                sx={inputSx}
+                sx={{ ...inputSx, overflow: 'auto', height: '100%' }}
               />
             </Grid>
             <Grid
@@ -327,7 +327,7 @@ function AnalysisForm() {
                 margin="normal"
                 multiline
                 minRows={7}
-                sx={inputSx}
+                sx={{ ...inputSx, overflow: 'auto' }}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
## Summary
- ensure long text fields scroll by adding overflow and height styles
- keep complaint and directives fields manageable at any length

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68606c830118832f9b4e04cfe1c2fed0