### PR TITLE
Update grid item widths for better responsive layout

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -176,7 +176,12 @@ function AnalysisForm() {
                 item
                 xs={12}
                 md={7}
-                sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  height: '100%',
+                  width: { xs: '100%', md: '50%' }
+                }}
               >
                 <TextField
                   label="Complaint"
@@ -193,7 +198,13 @@ function AnalysisForm() {
                 item
                 xs={12}
                 md={5}
-                sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                  height: '100%',
+                  width: { xs: '100%', md: '40%' }
+                }}
               >
                 <Autocomplete
                   fullWidth


### PR DESCRIPTION
## Summary
- tweak AnalysisForm grid widths for complaint and details fields

## Testing
- `python -m unittest discover`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68607d7f7b18832f8e858b696e2c06a1