### PR TITLE
Update AnalysisForm and tests

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -1,75 +1,67 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import AnalysisForm from '../components/AnalysisForm'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AnalysisForm from '../components/AnalysisForm';
 
 vi.mock('@mui/material/Autocomplete', () => ({
   __esModule: true,
-  default: ({ value, onChange, onInputChange, renderInput }) => {
-    const params = { inputProps: {}, InputProps: {} }
-    const { inputProps } = renderInput(params).props
-    const handler = onChange || onInputChange || (() => {})
+  default: ({ value, inputValue, onChange, onInputChange, renderInput }) => {
+    const params = { inputProps: {}, InputProps: {} };
+    const { inputProps } = renderInput(params).props;
+    const handler = onChange || onInputChange || (() => {});
     return (
       <input
-        data-testid={inputProps['data-testid']}
-        value={value || ''}
+        data-testid={inputProps['data-testid'] || inputProps.id}
+        value={inputValue || value || ''}
         onChange={(e) => handler(null, e.target.value)}
       />
-    )
+    );
   }
-}))
-
+}));
 
 beforeEach(() => {
-  global.fetch = vi.fn()
-})
+  global.fetch = vi.fn();
+});
 
 afterEach(() => {
-  vi.restoreAllMocks()
-})
+  vi.restoreAllMocks();
+});
 
-test('submits form and shows results', async () => {
+test('fetches options and logs analysis data', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ step: 'a' }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'done' }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ pdf: 'p', excel: 'e' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) });
 
-  render(<AnalysisForm />)
-  fetch.mockClear()
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-  fireEvent.change(screen.getByLabelText(/complaint/i), { target: { value: 'c' } })
-  fireEvent.change(screen.getByTestId('customer-input'), { target: { value: 'cu' } })
-  fireEvent.change(screen.getByTestId('subject-input'), { target: { value: 's' } })
-  fireEvent.change(screen.getByTestId('partcode-input'), { target: { value: 'p' } })
-  fireEvent.change(screen.getByTestId('method-input'), { target: { value: '8D' } })
-  fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
+  render(<AnalysisForm />);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
-  await screen.findByText(/done/)
-  await screen.findByText(/created successfully/i)
-  await screen.findByTestId('CheckCircleIcon')
-  expect(screen.getByTestId('PictureAsPdfIcon')).toBeInTheDocument()
-  expect(screen.getByTestId('FileDownloadIcon')).toBeInTheDocument()
-})
+  fireEvent.change(screen.getByLabelText(/şikayet/i), { target: { value: 'c' } });
+  fireEvent.change(screen.getByLabelText(/müşteri/i), { target: { value: 'cu' } });
+  fireEvent.change(screen.getByLabelText(/konu/i), { target: { value: 's' } });
+  fireEvent.change(screen.getByLabelText(/parça kodu/i), { target: { value: 'p' } });
+  fireEvent.change(screen.getByLabelText(/metot/i), { target: { value: '8D' } });
+  fireEvent.click(screen.getByRole('button', { name: /analiz et/i }));
 
-test('shows error on api failure', async () => {
+  expect(logSpy).toHaveBeenCalledWith({
+    complaint: 'c',
+    customer: 'cu',
+    subject: 's',
+    partCode: 'p',
+    method: '8D',
+    directives: ''
+  });
+});
+
+test('shows guide text when method selected', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
-    .mockResolvedValueOnce({ ok: false, status: 500 })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) });
 
-  render(<AnalysisForm />)
-  fetch.mockClear()
-  fireEvent.change(screen.getByLabelText(/complaint/i), { target: { value: 'c' } })
-  fireEvent.change(screen.getByTestId('customer-input'), { target: { value: 'cu' } })
-  fireEvent.change(screen.getByTestId('subject-input'), { target: { value: 's' } })
-  fireEvent.change(screen.getByTestId('partcode-input'), { target: { value: 'p' } })
-  fireEvent.change(screen.getByTestId('method-input'), { target: { value: '8D' } })
-  fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
+  render(<AnalysisForm />);
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
 
-  await waitFor(() => expect(fetch).toHaveBeenCalled())
-  await screen.findByText(/http 500/i)
-  expect(screen.getByText(/http 500/i)).toBeInTheDocument()
-})
+  fireEvent.change(screen.getByLabelText(/metot/i), { target: { value: '8D' } });
+  expect(screen.getByText(/eight disciplines/i)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/SampleForm.test.jsx
+++ b/frontend/src/__tests__/SampleForm.test.jsx
@@ -3,6 +3,6 @@ import SampleForm from '../components/SampleForm'
 
 it('renders analysis and query forms', () => {
   render(<SampleForm />)
-  expect(screen.getByRole('button', { name: /analyze/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /analiz et/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /query/i })).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- streamline `AnalysisForm` with simplified layout and API option fetching
- rewrite AnalysisForm tests for new behaviour
- adjust SampleForm test for new button label

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError for dotenv, fpdf, httpx)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68617a8aa40c832fb70a7504b62a85ac