### PR TITLE
Add importlib fallback for claims searcher

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import os
 
 from dotenv import load_dotenv
+from importlib import resources
 
 from difflib import SequenceMatcher
 from openpyxl import load_workbook
@@ -22,11 +23,14 @@ class ExcelClaimsSearcher:
         """Initialize with optional Excel file ``path``.
 
         When ``path`` is ``None``, ``CLAIMS_FILE_PATH`` is read from the
-        ``.env`` file. If the variable is unset, ``CC/claims.xlsx`` is used.
+        ``.env`` file. If the variable is unset, the bundled ``claims.xlsx``
+        inside the ``CC`` package is used.
         """
         if path is None:
             load_dotenv()
-            path = os.getenv("CLAIMS_FILE_PATH", "CC/claims.xlsx")
+            path = os.getenv("CLAIMS_FILE_PATH")
+            if path is None:
+                path = resources.files("CC").joinpath("claims.xlsx")
         self.path = Path(path)
 
     def search(

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -105,6 +105,22 @@ class ExcelClaimsSearchTest(unittest.TestCase):
                 self.assertTrue(mock_load.called)
                 self.assertEqual(searcher.path, Path("f"))
 
+    def test_bundled_file_outside_repo(self) -> None:
+        """Bundled Excel file should load when run outside the repo root."""
+        repo_root = Path(__file__).resolve().parents[1]
+        expected = repo_root / "CC" / "claims.xlsx"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                with patch.dict("os.environ", {}, clear=True), \
+                        patch.object(claims_excel, "load_dotenv"):
+                    searcher = ExcelClaimsSearcher()
+            finally:
+                os.chdir(cwd)
+        self.assertEqual(searcher.path, expected)
+        self.assertTrue(len(searcher.search({})) > 0)
+
     def test_year_range(self) -> None:
         """Records should be filterable by a start and end year."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- load bundled claims file via `importlib.resources` when no path or env var is provided
- add regression test ensuring bundled file works outside repo root

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6861c27e252c832f8ff14e2a9f5935d1