### PR TITLE
Add complaint filtering controls

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -60,3 +60,28 @@ test('shows guide text when method selected', async () => {
   })
   expect(methodInput.value).toBe('8D')
 })
+
+test('fetches filtered claims', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ excel: [{ complaint: 'x' }], store: [] })
+    })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.change(screen.getByTestId('customer-input'), {
+    target: { value: 'acme' }
+  })
+  fireEvent.click(screen.getByLabelText('Müşteri'))
+  fireEvent.click(screen.getByRole('button', { name: /şikayetleri getir/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+  const url = fetch.mock.calls[3][0]
+  expect(url).toContain('customer=acme')
+  await screen.findByText(/"x"/)
+})

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -19,6 +19,10 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import FileDownloadIcon from '@mui/icons-material/FileDownload'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Checkbox from '@mui/material/Checkbox'
+import Select from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
 import { API_BASE } from '../api'
 
 const METHODS = ['8D', 'A3', 'Ishikawa', '5N1K', 'DMAIC']
@@ -65,6 +69,14 @@ function AnalysisForm() {
   const [customerOptions, setCustomerOptions] = useState([])
   const [subjectOptions, setSubjectOptions] = useState([])
   const [partCodeOptions, setPartCodeOptions] = useState([])
+  const [useCustomerFilter, setUseCustomerFilter] = useState(false)
+  const [usePartCodeFilter, setUsePartCodeFilter] = useState(false)
+  const [useSubjectFilter, setUseSubjectFilter] = useState(false)
+  const currentYear = new Date().getFullYear()
+  const years = Array.from({ length: 10 }, (_, i) => `${currentYear - i}`)
+  const [selectedYear, setSelectedYear] = useState('')
+  const [claims, setClaims] = useState(null)
+  const [claimsError, setClaimsError] = useState('')
 
   useEffect(() => {
     const fetchOptions = async (field, setter) => {
@@ -136,6 +148,30 @@ function AnalysisForm() {
       setError(err.message)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleFetchClaims = async () => {
+    const params = new URLSearchParams()
+    if (useCustomerFilter && customer) params.append('customer', customer)
+    if (usePartCodeFilter && partCode) params.append('part_code', partCode)
+    if (useSubjectFilter && subject) params.append('subject', subject)
+    if (selectedYear) params.append('start_year', selectedYear)
+    const url =
+      params.toString().length > 0
+        ? `${API_BASE}/complaints?${params.toString()}`
+        : `${API_BASE}/complaints`
+    try {
+      const res = await fetch(url)
+      if (!res.ok) {
+        throw new Error(`HTTP error ${res.status}`)
+      }
+      const data = await res.json()
+      setClaims(data)
+      setClaimsError('')
+    } catch (err) {
+      setClaimsError(err.message)
+      setClaims(null)
     }
   }
 
@@ -345,6 +381,68 @@ function AnalysisForm() {
               />
             </Grid>
           </Grid>
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={useCustomerFilter}
+              onChange={(e) => setUseCustomerFilter(e.target.checked)}
+            />
+          }
+          label="Müşteri"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={usePartCodeFilter}
+              onChange={(e) => setUsePartCodeFilter(e.target.checked)}
+            />
+          }
+          label="Parça Kodu"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={useSubjectFilter}
+              onChange={(e) => setUseSubjectFilter(e.target.checked)}
+            />
+          }
+          label="Konu"
+        />
+        <Select
+          value={selectedYear}
+          onChange={(e) => setSelectedYear(e.target.value)}
+          displayEmpty
+          size="small"
+          sx={{ minWidth: 90 }}
+        >
+          <MenuItem value="">
+            <em>Yıl</em>
+          </MenuItem>
+          {years.map((y) => (
+            <MenuItem key={y} value={y}>
+              {y}
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
+      <Button
+        variant="outlined"
+        onClick={handleFetchClaims}
+        sx={{ mt: 2, px: 3, py: 1 }}
+      >
+        ŞİKAYETLERİ GETİR
+      </Button>
+      {claimsError && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          {claimsError}
+        </Alert>
+      )}
+      {claims && (
+        <pre style={{ whiteSpace: 'pre-wrap', marginTop: '8px' }}>
+          {JSON.stringify(claims, null, 2)}
+        </pre>
+      )}
       <Button
         type="submit"
         variant="contained"


### PR DESCRIPTION
## Summary
- enable filtering complaints in `AnalysisForm`
- test new complaint filtering feature

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6861d442b100832fa1090047dd6c4bd0