### PR TITLE
Remove leftover chart backgrounds

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -324,7 +324,6 @@ function AnalysisForm() {
           sx={{
             width: '100%',
             height: '49%',
-            bgcolor: '#fff',
             borderRadius: 2,
             mb: 1,
             p: 2,
@@ -361,7 +360,6 @@ function AnalysisForm() {
           sx={{
             width: '100%',
             height: '49%',
-            bgcolor: '#fff',
             borderRadius: 2,
             p: 2,
             display: 'flex',


### PR DESCRIPTION
## Summary
- strip `bgcolor` props from chart containers in `AnalysisForm`

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_b_6862394f44e4832fbd8a6954d6706b65