### PR TITLE
Fix dark mode text

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,7 +4,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: #1a1a1a;
   background: linear-gradient(135deg, #e8edf5 0%, #ffffff 100%);
 
   font-synthesis: none;
@@ -32,7 +31,6 @@ h1 {
   font-size: 3.2em;
   line-height: 1.1;
   font-family: 'Poppins', 'Inter', sans-serif;
-  color: #002855;
 }
 
 button {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -26,7 +26,8 @@ function Home() {
             variant="h4"
             component="h1"
             gutterBottom
-            sx={{ color: '#002855', fontFamily: 'Poppins, Inter, sans-serif' }}
+            sx={{ fontFamily: 'Poppins, Inter, sans-serif' }}
+            color="text.primary"
           >
             Plasma QR
           </Typography>


### PR DESCRIPTION
## Summary
- remove body color override from CSS
- use theme primary text color for the home page heading

## Testing
- `python -m unittest discover`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6862695f2068832f8e00582a962d334f