### PR TITLE
Add packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,9 @@ pyinstaller --onefile run_app.py \
 ```
 
 Oluşan `dist/run_app.exe` dosyası müşteri bilgisayarında doğrudan
+
 çalıştırılabilir.
+Bu komutlari `scripts/package_exe.sh` betigi ile de calistirabilirsiniz.
 
 ## Frontend
 

--- a/scripts/package_exe.sh
+++ b/scripts/package_exe.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build single-file executable with PyInstaller
+# Must be run on Windows or using Wine/compat layer for Windows output.
+
+pyinstaller --onefile run_app.py \
+  --copy-metadata streamlit \
+  --add-data 'Guidelines/*:Guidelines' \
+  --add-data 'Prompts/*:Prompts' \
+  --add-data 'Fonts/*:Fonts' \
+  --add-data 'Logo/*:Logo' \
+  --add-data "UI/streamlit_app.py:UI" \
+  --add-data 'CC/*:CC'


### PR DESCRIPTION
## Summary
- include `package_exe.sh` helper for building a PyInstaller executable
- reference the helper script in README

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68626cab3f54832f9266514a459928e8