### PR TITLE
Add Electron launcher setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Fonts/*.pkl
 frontend/node_modules/
 frontend/dist/
 complaints.json
+electron/dist/
+
+electron/node_modules/
+

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,44 @@
+const { app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+const path = require('path');
+
+let pythonProcess;
+
+function createWindow() {
+    const mainWindow = new BrowserWindow({
+        width: 800,
+        height: 600,
+        show: false,
+    });
+
+    const indexPath = path.join(__dirname, '..', 'frontend', 'dist', 'index.html');
+    mainWindow.loadFile(indexPath);
+    mainWindow.once('ready-to-show', () => {
+        mainWindow.show();
+    });
+}
+
+app.whenReady().then(() => {
+    pythonProcess = spawn('python', ['../run_api.py'], {
+        stdio: 'ignore',
+        detached: true,
+    });
+    pythonProcess.unref();
+
+    createWindow();
+
+    app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+            createWindow();
+        }
+    });
+});
+
+app.on('window-all-closed', () => {
+    if (pythonProcess) {
+        pythonProcess.kill();
+    }
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "plasma-electron",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dist": "electron-builder"
+  },
+  "dependencies": {
+    "electron": "^30.0.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "files": [
+      "main.js"
+    ],
+    "extraResources": [
+      {
+        "from": "../frontend/dist",
+        "to": "frontend"
+      },
+      {
+        "from": "../run_api.py",
+        "to": "run_api.py"
+      }
+    ],
+    "win": {
+      "target": "nsis"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- integrate electron app skeleton
- spawn hidden Python backend on start
- add packaging config with electron-builder
- ignore electron build artifacts

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_686274975ce8832f9bbb93af243cfc72