### PR TITLE
Bundle API with PyInstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 # Distribution / packaging
 build/
 dist/
+run_api.spec
 *.egg-info/
 
 # Misc
@@ -24,6 +25,8 @@ frontend/node_modules/
 frontend/dist/
 complaints.json
 electron/dist/
+
+electron/backend/
 
 electron/node_modules/
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -19,7 +19,9 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-    pythonProcess = spawn('python', ['../run_api.py'], {
+    const exeName = process.platform === 'win32' ? 'run_api.exe' : 'run_api';
+    const exePath = path.join(__dirname, 'backend', exeName);
+    pythonProcess = spawn(exePath, [], {
         stdio: 'ignore',
         detached: true,
     });

--- a/electron/package.json
+++ b/electron/package.json
@@ -4,7 +4,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder"
+    "build:backend": "pyinstaller --onefile --distpath backend ../run_api.py",
+    "dist": "npm run build:backend && electron-builder",
+    "postinstall": "npm run build:backend"
   },
   "dependencies": {
     "electron": "^30.0.0"
@@ -22,8 +24,8 @@
         "to": "frontend"
       },
       {
-        "from": "../run_api.py",
-        "to": "run_api.py"
+        "from": "backend",
+        "to": "backend"
       }
     ],
     "win": {


### PR DESCRIPTION
## Summary
- ignore build artifacts and packaged backend
- build `run_api.py` into an executable during install
- execute the bundled binary from Electron

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_b_686275aa1be4832fa3c5641d3dcf2fe1