### PR TITLE
Log warning for missing complaints Excel

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from pathlib import Path
 from datetime import datetime
 import os
+import logging
 
 from dotenv import load_dotenv
 from importlib import resources
@@ -61,6 +62,7 @@ class ExcelClaimsSearcher:
             Matching rows as dictionaries with lowercase keys.
         """
         if not self.path.exists():
+            logging.warning("Excel file not found at %s", self.path)
             return []
 
         wb = load_workbook(self.path, read_only=True)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ python configure_env.py
 Bu islemin ardindan `CLAIMS_FILE_PATH` degiskeni de `.env` dosyaniza eklenmis
 olur ve uygulama muster sikayetlerini bu dosyadan okur.
 
+Dosya mevcut degilse `ExcelClaimsSearcher.search` bos liste dondurur ve loglara
+bir uyari mesaji yazar.
+
 Gecerli bir anahtar saglanmadiginda veya baglanti kurulamazsa analiz
 sonuclari icin yer tutucu metinler dondurulur.
 

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -105,6 +105,16 @@ class ExcelClaimsSearchTest(unittest.TestCase):
                 self.assertTrue(mock_load.called)
                 self.assertEqual(searcher.path, Path("f"))
 
+    def test_missing_file_logs_warning(self) -> None:
+        """A warning should be logged when the Excel file is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "missing.xlsx")
+            searcher = ExcelClaimsSearcher(file_path)
+            with self.assertLogs(level="WARNING") as log:
+                result = searcher.search({})
+            self.assertEqual(result, [])
+            self.assertIn("Excel file not found", "\n".join(log.output))
+
     def test_bundled_file_outside_repo(self) -> None:
         """Bundled Excel file should load when run outside the repo root."""
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- log a warning when Excel file is absent in `ExcelClaimsSearcher.search`
- test the warning emission
- document the warning behaviour in README

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68628f68a75c832fa145e19b419b1944