### PR TITLE
Add error handling to AnalysisForm

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -143,3 +143,23 @@ test('runs analyze workflow', async () => {
   await screen.findByTestId('pdf-link')
   await screen.findByTestId('excel-link')
 })
+
+test('shows error alert on analyze failure', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
+    .mockRejectedValueOnce(new Error('fail'))
+
+  render(<AnalysisForm initialMethod="8D" />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.change(screen.getByLabelText('Şikayet (Complaint)'), {
+    target: { value: 'c' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: /analiz et/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(5))
+  expect(screen.getByRole('alert')).toHaveTextContent('fail')
+})

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -82,6 +82,7 @@ function AnalysisForm({
   const [selectedYear, setSelectedYear] = useState('');
   const [claims, setClaims] = useState(null);
   const [claimsError, setClaimsError] = useState('');
+  const [error, setError] = useState('');
   const [reviewText, setReviewText] = useState('');
   const [reportPaths, setReportPaths] = useState(null);
   const [monthRange, setMonthRange] = useState([0, 11]);
@@ -129,6 +130,7 @@ function AnalysisForm({
     fetchOptions('part_code', setPartCodeOptions);
   }, []);
   const handleAnalyze = async () => {
+    setError('');
     const details = {
       complaint,
       customer,
@@ -164,6 +166,7 @@ function AnalysisForm({
       setReportPaths(paths);
     } catch (err) {
       console.error(err);
+      setError(err.message || 'Bir hata oluştu');
     }
   };
   const handleFetchClaims = async () => {
@@ -466,6 +469,11 @@ function AnalysisForm({
           <pre style={{ whiteSpace: 'pre-wrap', marginTop: '8px' }}>
             {JSON.stringify(claims, null, 2)}
           </pre>
+        )}
+        {error && (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {error}
+          </Alert>
         )}
         {reviewText && (
           <Box sx={{ mt: 2 }}>


### PR DESCRIPTION
## Summary
- track API errors in AnalysisForm
- display an error alert if analysis fails
- test analyze failure logic

## Testing
- `python -m unittest discover`
- `npx --yes vitest run --config frontend/vite.config.js` *(fails: cannot find jsdom)*

------
https://chatgpt.com/codex/tasks/task_b_6862985b9df4832f885c105e171213f3