### PR TITLE
Add regression test for analyze error alert

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -163,3 +163,24 @@ test('shows error alert on analyze failure', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(5))
   expect(screen.getByRole('alert')).toHaveTextContent('fail')
 })
+
+test('shows alert when analyze request rejects', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
+    .mockRejectedValueOnce(new Error('server error'))
+
+  render(<AnalysisForm initialMethod="8D" />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.change(screen.getByLabelText('Şikayet (Complaint)'), {
+    target: { value: 'c' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: /analiz et/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(5))
+  const alert = await screen.findByRole('alert')
+  expect(alert).toHaveTextContent('server error')
+})


### PR DESCRIPTION
## Summary
- add a new test to ensure an error `<Alert>` appears when the analyze request fails

## Testing
- `python -m unittest discover`
- `npx vitest run` *(fails: cannot find @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_b_68629c7bdec4832facba461934542944