### PR TITLE
Switch to fishbone-chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ npm install
 npm run dev
 ```
 
-Balık kılçığı diyagramı için `@hophiphip/react-fishbone` paketini kullanıyoruz.
+Balık kılçığı diyagramı için `fishbone-chart` paketini kullanıyoruz.
 `AnalysisForm` bileşeni Ishikawa yöntemi seçildiğinde
-`<FishboneDiagram items={items} />` şeklinde diyagramı gösterir.
+`<FishboneDiagram data={data} />` şeklinde diyagramı gösterir.
 
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@hophiphip/react-fishbone": "^0.5.3",
         "@mui/icons-material": "^7.1.2",
         "@mui/material": "^7.1.2",
         "@mui/x-date-pickers": "^8.6.0",
         "date-fns": "^4.1.0",
+        "fishbone-chart": "^1.0.24",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "recharts": "^2.9.0"
@@ -1220,19 +1220,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@hophiphip/react-fishbone": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@hophiphip/react-fishbone/-/react-fishbone-0.5.3.tgz",
-      "integrity": "sha512-29jQ061T9OOHVRszWP9yMh1Chm2HtYAAEAOZ3y4Vzi+m54QQZfc/1OwcH1R4LE4ngAGppZMUF1GpTVEa8fhMuA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@xyflow/react": "^12.3.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2163,15 +2150,6 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
@@ -2202,12 +2180,6 @@
         "@types/d3-time": "*"
       }
     },
-    "node_modules/@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
@@ -2228,25 +2200,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
-    },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2278,7 +2231,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2496,38 +2448,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@xyflow/react": {
-      "version": "12.8.1",
-      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.8.1.tgz",
-      "integrity": "sha512-t5Rame4Gc/540VcOZd28yFe9Xd8lyjKUX+VTiyb1x4ykNXZH5zyDmsu+lj9je2O/jGBVb0pj1Vjcxrxyn+Xk2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@xyflow/system": "0.0.65",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.0"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@xyflow/system": {
-      "version": "0.0.65",
-      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.65.tgz",
-      "integrity": "sha512-AliQPQeurQMoNlOdySnRoDQl9yDSA/1Lqi47Eo0m98lHcfrTdD9jK75H0tiGj+0qRC10SKNUXyMkT0KL0opg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-drag": "^3.0.7",
-        "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-selection": "^3.0.10",
-        "@types/d3-transition": "^3.0.8",
-        "@types/d3-zoom": "^3.0.8",
-        "d3-drag": "^3.0.0",
-        "d3-interpolate": "^3.0.1",
-        "d3-selection": "^3.0.0",
-        "d3-zoom": "^3.0.0"
-      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2800,12 +2720,6 @@
         "node": "*"
       }
     },
-    "node_modules/classcat": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
-      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
-      "license": "MIT"
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2943,28 +2857,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -3020,15 +2912,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -3070,41 +2953,6 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -3609,6 +3457,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fishbone-chart": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/fishbone-chart/-/fishbone-chart-1.0.24.tgz",
+      "integrity": "sha512-SOHiVJORUn9wXNxwq6sne8V3EseCZMvNGnyXncPKcaS1Dkzo4VNX146lezY/Ebq/H7uvwwoZjMk03UlN0nrCWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.4",
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/flat-cache": {
@@ -5206,15 +5069,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
@@ -6541,34 +6395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@hophiphip/react-fishbone": "^0.5.3",
+    "fishbone-chart": "^1.0.24",
     "@mui/icons-material": "^7.1.2",
     "@mui/material": "^7.1.2",
     "@mui/x-date-pickers": "^8.6.0",

--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -16,7 +16,7 @@ vi.mock('@mui/material/Autocomplete', () => ({
     )
   }
 }))
-vi.mock('@hophiphip/react-fishbone', () => ({
+vi.mock('fishbone-chart', () => ({
   default: () => <div data-testid="fishbone">diagram</div>
 }), { virtual: true })
 

--- a/frontend/src/__tests__/FishboneDiagram.test.jsx
+++ b/frontend/src/__tests__/FishboneDiagram.test.jsx
@@ -1,12 +1,14 @@
-vi.mock('@hophiphip/react-fishbone', () => ({
-  default: ({ items }) => <div data-testid="fishbone">{items.label}</div>
+vi.mock('fishbone-chart', () => ({
+  default: ({ data }) => (
+    <div data-testid="fishbone">{Object.keys(data)[0]}</div>
+  )
 }), { virtual: true })
 
 import { render, screen } from '@testing-library/react'
 import FishboneDiagram from '../components/FishboneDiagram'
 
 it('renders items label', () => {
-  const items = { label: 'Root' }
-  render(<FishboneDiagram items={items} />)
+  const data = { Root: {} }
+  render(<FishboneDiagram data={data} />)
   expect(screen.getByTestId('fishbone')).toHaveTextContent('Root')
 })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -42,16 +42,15 @@ const GUIDE_TEXT = {
   DMAIC:
     'DMAIC, süreç iyileştirme için kullanılan sistematik bir problem çözme metodudur.'
 };
-const FISHBONE_ITEMS = {
-  label: 'Problem',
-  children: [
-    { label: 'Method' },
-    { label: 'Material' },
-    { label: 'Machine' },
-    { label: 'Measurement' },
-    { label: 'Man' },
-    { label: 'Environment' }
-  ]
+const FISHBONE_DATA = {
+  Problem: {
+    Method: [],
+    Material: [],
+    Machine: [],
+    Measurement: [],
+    Man: [],
+    Environment: []
+  }
 };
 const inputSx = {
   '& .MuiOutlinedInput-root': {
@@ -353,7 +352,7 @@ function AnalysisForm({
             )}
             {method === 'Ishikawa' && (
               <Box sx={{ mt: 2 }}>
-                <FishboneDiagram items={FISHBONE_ITEMS} />
+                <FishboneDiagram data={FISHBONE_DATA} />
               </Box>
             )}
           </Box>

--- a/frontend/src/components/FishboneDiagram.jsx
+++ b/frontend/src/components/FishboneDiagram.jsx
@@ -1,8 +1,7 @@
-import Fishbone from '@hophiphip/react-fishbone';
-import '@hophiphip/react-fishbone/style.css';
+import FishboneChart from 'fishbone-chart';
 
-function FishboneDiagram({ items }) {
-  return <Fishbone items={items} />;
+function FishboneDiagram({ data }) {
+  return <FishboneChart data={data} />;
 }
 
 export default FishboneDiagram;


### PR DESCRIPTION
## Summary
- drop @hophiphip/react-fishbone dependency
- add fishbone-chart and update FishboneDiagram component
- render new FishboneDiagram when Ishikawa method is chosen
- update tests for new fishbone-chart
- document new library in README

## Testing
- `npx vitest run` *(fails: Test Files 1 failed | 7 passed)*
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6862a8196fe8832fa4abffb34c7ce5b9