### PR TITLE
Include typed values in ComplaintFetcher query params

### DIFF
--- a/frontend/src/__tests__/ComplaintFetcher.test.jsx
+++ b/frontend/src/__tests__/ComplaintFetcher.test.jsx
@@ -17,14 +17,21 @@ test('fetches complaints and shows data', async () => {
 
   render(<ComplaintFetcher />)
 
-  fireEvent.click(screen.getByLabelText('Müşteri'))
-  fireEvent.click(screen.getByLabelText('Konu'))
+  const inputs = screen.getAllByRole('textbox')
+  const checks = screen.getAllByRole('checkbox')
+  fireEvent.change(inputs[0], { target: { value: 'cust' } })
+  fireEvent.click(checks[0])
+  fireEvent.change(inputs[1], { target: { value: 'subj' } })
+  fireEvent.click(checks[1])
+  fireEvent.change(inputs[2], { target: { value: 'part' } })
+  fireEvent.click(checks[2])
   fireEvent.click(screen.getByRole('button', { name: /fetch complaints/i }))
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
   const url = fetch.mock.calls[0][0]
-  expect(url).toContain('customer=1')
-  expect(url).toContain('subject=1')
+  expect(url).toContain('customer=cust')
+  expect(url).toContain('subject=subj')
+  expect(url).toContain('part_code=part')
   await screen.findByText(/"a"/)
   await screen.findByText(/"b"/)
 })
@@ -34,7 +41,8 @@ test('shows error when api fails', async () => {
 
   render(<ComplaintFetcher />)
 
-  fireEvent.click(screen.getByLabelText('Müşteri'))
+  fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'x' } })
+  fireEvent.click(screen.getAllByRole('checkbox')[0])
   fireEvent.click(screen.getByRole('button', { name: /fetch complaints/i }))
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
   await screen.findByText(/http error 404/i)

--- a/frontend/src/components/ComplaintFetcher.jsx
+++ b/frontend/src/components/ComplaintFetcher.jsx
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
+import TextField from '@mui/material/TextField'
 import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import { API_BASE } from '../api'
@@ -15,15 +16,18 @@ function ComplaintFetcher() {
   const [useCustomer, setUseCustomer] = useState(false)
   const [useSubject, setUseSubject] = useState(false)
   const [usePartCode, setUsePartCode] = useState(false)
+  const [customer, setCustomer] = useState('')
+  const [subject, setSubject] = useState('')
+  const [partCode, setPartCode] = useState('')
   const currentYear = new Date().getFullYear()
   const years = Array.from({ length: 5 }, (_, i) => `${currentYear - i}`)
   const [selectedYear, setSelectedYear] = useState('')
 
   const fetchData = async () => {
     const params = new URLSearchParams()
-    if (useCustomer) params.append('customer', '1')
-    if (useSubject) params.append('subject', '1')
-    if (usePartCode) params.append('part_code', '1')
+    if (useCustomer && customer) params.append('customer', customer)
+    if (useSubject && subject) params.append('subject', subject)
+    if (usePartCode && partCode) params.append('part_code', partCode)
     if (selectedYear) params.append('year', selectedYear)
     const url =
       params.toString().length > 0
@@ -47,15 +51,36 @@ function ComplaintFetcher() {
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
         <FormControlLabel
           control={<Checkbox checked={useCustomer} onChange={(e) => setUseCustomer(e.target.checked)} />}
-          label="Müşteri"
+          label={
+            <TextField
+              label="Müşteri"
+              size="small"
+              value={customer}
+              onChange={(e) => setCustomer(e.target.value)}
+            />
+          }
         />
         <FormControlLabel
           control={<Checkbox checked={useSubject} onChange={(e) => setUseSubject(e.target.checked)} />}
-          label="Konu"
+          label={
+            <TextField
+              label="Konu"
+              size="small"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+            />
+          }
         />
         <FormControlLabel
           control={<Checkbox checked={usePartCode} onChange={(e) => setUsePartCode(e.target.checked)} />}
-          label="Parça Kodu"
+          label={
+            <TextField
+              label="Parça Kodu"
+              size="small"
+              value={partCode}
+              onChange={(e) => setPartCode(e.target.value)}
+            />
+          }
         />
         <Select
           value={selectedYear}


### PR DESCRIPTION
## Summary
- support entering customer, subject and part code in `ComplaintFetcher`
- send these typed values as query params when fetching complaints
- update tests to reflect new filter behaviour

## Testing
- `python -m unittest discover`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862ad3c61f4832fb2f67563c49fd5de