### PR TITLE
Improve report error handling

### DIFF
--- a/ReportGenerator/__init__.py
+++ b/ReportGenerator/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict
 from pathlib import Path
 import os
+import logging
 
 from fpdf import FPDF
 from openpyxl import Workbook
@@ -13,6 +14,8 @@ from uuid import uuid4
 DEFAULT_FONT_PATH = Path(__file__).resolve().parents[1] / "Fonts" / "DejaVuSans.ttf"
 
 from GuideManager import GuideManager
+
+logger = logging.getLogger(__name__)
 
 
 class ReportGenerator:
@@ -99,7 +102,11 @@ class ReportGenerator:
             line = f"{key}: {response}"
             width = getattr(pdf, "epw", 0)
             pdf.multi_cell(width, 10, txt=line)
-        pdf.output(str(pdf_path))
+        try:
+            pdf.output(str(pdf_path))
+        except Exception:
+            logger.exception("Failed to create report file")
+            raise
 
         # Create Excel
         wb = Workbook()
@@ -111,7 +118,11 @@ class ReportGenerator:
         ws.append(["Step", "Response"])
         for key, response in entries:
             ws.append([key, response])
-        wb.save(str(excel_path))
+        try:
+            wb.save(str(excel_path))
+        except Exception:
+            logger.exception("Failed to create report file")
+            raise
 
         return {"pdf": str(pdf_path), "excel": str(excel_path)}
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -82,7 +82,11 @@ class ReportBody(BaseModel):
 def report(body: ReportBody) -> Dict[str, str]:
     """Generate PDF and Excel reports via ``ReportGenerator``."""
     logger.info("Report request body: %s", body.dict())
-    paths = reporter.generate(body.analysis, body.complaint_info, REPORT_DIR)
+    try:
+        paths = reporter.generate(body.analysis, body.complaint_info, REPORT_DIR)
+    except Exception as exc:  # pragma: no cover - unexpected failure
+        logger.exception("Report generation failed")
+        raise HTTPException(status_code=500, detail="Report generation failed") from exc
     result = {
         "pdf": f"/reports/{Path(paths['pdf']).name}",
         "excel": f"/reports/{Path(paths['excel']).name}",

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -144,6 +144,18 @@ class ReportGeneratorTest(unittest.TestCase):
         occurrences = [line for line in pdf.lines if 'dup' in line]
         self.assertEqual(len(occurrences), 1)
 
+    def test_generate_logs_on_pdf_error(self) -> None:
+        """Errors during PDF output should be logged and re-raised."""
+        analysis = {"Step": {"response": "foo"}}
+        info = {"customer": "c"}
+        with tempfile.TemporaryDirectory() as tmpdir, \
+             patch.object(FPDF, "output", side_effect=OSError("boom")), \
+             self.assertLogs("ReportGenerator", level="ERROR") as log:
+            with self.assertRaises(OSError):
+                self.generator.generate(analysis, info, tmpdir)
+
+        self.assertIn("Failed to create report file", "\n".join(log.output))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add logger to ReportGenerator
- log failures when saving PDF or Excel files
- handle generation errors in the API layer
- test that report generation logs exceptions on save failure

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_68639c23c030832fa5828dcab2227407