### PR TITLE
Add logging helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ pip install -r requirements.txt
 python run_api.py
 ```
 
+Uygulama calisirken log seviyesini `LOG_LEVEL` degiskeniyle
+belirleyebilirsiniz. Varsayilan seviye `INFO` olup ayrintili loglar
+icin `LOG_LEVEL=DEBUG` tanimlayin.
+
 Sunucu varsayilan olarak `http://localhost:8000` adresinde
 asagidaki uclari sunar:
 

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -1,0 +1,17 @@
+"""Utilities for configuring application logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+__all__ = ["configure_logging"]
+
+
+def configure_logging() -> None:
+    """Initialize basic logging if no handlers are present."""
+    if not logging.getLogger().handlers:
+        level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+        level = getattr(logging, level_name, logging.INFO)
+        logging.basicConfig(level=level)
+

--- a/run_api.py
+++ b/run_api.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from dotenv import load_dotenv
 import uvicorn
 
+from api.logging_config import configure_logging
+
 from api import app
 
 
 def main() -> None:
     """Start the API server."""
+    configure_logging()
     load_dotenv()
     uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,47 @@
+import logging
+import os
+import unittest
+from unittest.mock import patch
+
+from api.logging_config import configure_logging
+
+
+class LoggingConfigTest(unittest.TestCase):
+    """Tests for the logging configuration helper."""
+
+    def setUp(self) -> None:
+        self.root = logging.getLogger()
+        self.orig_handlers = self.root.handlers[:]
+        for handler in self.root.handlers:
+            self.root.removeHandler(handler)
+
+    def tearDown(self) -> None:
+        for handler in self.root.handlers:
+            self.root.removeHandler(handler)
+        for handler in self.orig_handlers:
+            self.root.addHandler(handler)
+
+    def test_basic_config_called_no_handlers(self) -> None:
+        with patch("logging.basicConfig") as mock_basic:
+            configure_logging()
+            mock_basic.assert_called_once_with(level=logging.INFO)
+
+    def test_level_from_env(self) -> None:
+        with patch("logging.basicConfig") as mock_basic, \
+             patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}):
+            configure_logging()
+            mock_basic.assert_called_once_with(level=logging.DEBUG)
+
+    def test_no_config_when_handlers_exist(self) -> None:
+        handler = logging.NullHandler()
+        self.root.addHandler(handler)
+        try:
+            with patch("logging.basicConfig") as mock_basic:
+                configure_logging()
+                mock_basic.assert_not_called()
+        finally:
+            self.root.removeHandler(handler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -9,8 +9,10 @@ class RunAPITest(unittest.TestCase):
     def test_main_invokes_uvicorn(self) -> None:
         module = importlib.import_module("run_api")
         with patch.object(module, "load_dotenv") as mock_load, \
-             patch.object(module, "uvicorn") as mock_uvicorn:
+             patch.object(module, "uvicorn") as mock_uvicorn, \
+             patch.object(module, "configure_logging") as mock_conf:
             module.main()
+            mock_conf.assert_called_once()
             mock_load.assert_called_once()
             mock_uvicorn.run.assert_called_once_with(module.app, host="0.0.0.0", port=8000)
 


### PR DESCRIPTION
## Summary
- add `api.logging_config.configure_logging` helper
- initialize logging in `run_api.py`
- document `LOG_LEVEL` usage in README
- test logging helper and update run_api tests

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6863b39b941c832fb48b9fa6dd4b1ab4