### PR TITLE
Add debug logs for LLMAnalyzer prompts

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -69,6 +69,10 @@ class LLMAnalyzer:
     def _query_llm(self, system_prompt: str, user_prompt: str) -> str:
         """Return the LLM response for the given prompt pair."""
         self.logger.debug("LLMAnalyzer._query_llm start")
+        truncated_sys = system_prompt.replace("\n", " ")[:200]
+        truncated_user = user_prompt.replace("\n", " ")[:200]
+        self.logger.debug("system_prompt: %s", truncated_sys)
+        self.logger.debug("user_prompt: %s", truncated_user)
         try:
             from openai import OpenAI  # type: ignore
         except ImportError as exc:  # pragma: no cover - import errors not expected
@@ -91,6 +95,7 @@ class LLMAnalyzer:
             if tokens is not None:
                 self.logger.info("LLMAnalyzer tokens used: %s", tokens)
             result = response.choices[0].message.content.strip()
+            self.logger.debug("LLMAnalyzer returned: %s", result.replace("\n", " ")[:200])
             self.logger.debug("LLMAnalyzer._query_llm end")
             return result
         except Exception as exc:  # pragma: no cover - network issues

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -127,7 +127,7 @@ class LLMAnalyzerTest(unittest.TestCase):
         self.assertEqual(analyzer.model, "gpt-test")
 
     def test_query_llm_logs_tokens(self) -> None:
-        """Successful calls should log start, token usage and end messages."""
+        """Successful calls should emit debug logs with prompts and result."""
         mock_openai = types.ModuleType("openai")
         usage = types.SimpleNamespace(total_tokens=5)
         response = types.SimpleNamespace(
@@ -144,7 +144,10 @@ class LLMAnalyzerTest(unittest.TestCase):
         self.assertEqual(result, "ok")
         messages = "\n".join(log.output)
         self.assertIn("LLMAnalyzer._query_llm start", messages)
+        self.assertIn("system_prompt: sys", messages)
+        self.assertIn("user_prompt: prompt", messages)
         self.assertIn("INFO:LLMAnalyzer:LLMAnalyzer tokens used: 5", messages)
+        self.assertIn("LLMAnalyzer returned: ok", messages)
         self.assertIn("LLMAnalyzer._query_llm end", messages)
 
 


### PR DESCRIPTION
## Summary
- log truncated prompts and return text in `_query_llm`
- verify new debug logs in `tests/test_llm_analyzer.py`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6863d0c5e868832fa22fd0ca921df8d0