### PR TITLE
Fix showing analysis report in UI

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -139,6 +139,7 @@ test('runs analyze workflow', async () => {
   expect(fetch.mock.calls[4][0]).toMatch(/\/analyze$/)
   expect(fetch.mock.calls[5][0]).toMatch(/\/review$/)
   expect(fetch.mock.calls[6][0]).toMatch(/\/report$/)
+  await screen.findByTestId('analysis-text')
   await screen.findByTestId('review-text')
   await screen.findByTestId('pdf-link')
   await screen.findByTestId('excel-link')
@@ -185,6 +186,7 @@ test('shows error alert on empty report response', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(7))
   const alert = await screen.findAllByRole('alert')
   expect(alert[1]).toHaveTextContent('Sunucudan beklenmeyen boş yanıt alındı')
+  await screen.findByTestId('analysis-text')
   expect(await screen.findByTestId('review-text')).toHaveTextContent('r')
 })
 

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -84,6 +84,7 @@ function AnalysisForm({
   const [claimsError, setClaimsError] = useState('');
   const [error, setError] = useState('');
   const [reviewText, setReviewText] = useState('');
+  const [analysisText, setAnalysisText] = useState('');
   const [reportPaths, setReportPaths] = useState(null);
   const [loading, setLoading] = useState(false);
   const [monthRange, setMonthRange] = useState([0, 11]);
@@ -161,6 +162,7 @@ function AnalysisForm({
         setError('Sunucudan beklenmeyen boş yanıt alındı');
         return;
       }
+      setAnalysisText(analysis.full_text);
 
       const reviewRes = await fetch(`${API_BASE}/review`, {
         method: 'POST',
@@ -531,6 +533,15 @@ function AnalysisForm({
           <Alert severity="error" sx={{ mt: 1 }}>
             {error}
           </Alert>
+        )}
+        {analysisText && (
+          <Box sx={{ mt: 2 }}>
+            <Card variant="outlined" sx={{ p: 2, backgroundColor: '#f9f9f9' }}>
+              <Typography data-testid="analysis-text" sx={{ whiteSpace: 'pre-line' }}>
+                {analysisText}
+              </Typography>
+            </Card>
+          </Box>
         )}
         {reviewText && (
           <Box sx={{ mt: 2 }}>


### PR DESCRIPTION
## Summary
- store full report text in the `AnalysisForm` state
- render analysis text in its own card
- test that analysis text appears after running analyze

## Testing
- `python -m unittest discover`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6863d6abc634832fadd14cd4a0210eda