### PR TITLE
Update frontend handlers for new API keys

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -71,7 +71,7 @@ test('fetches filtered claims', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ excel: [{ complaint: 'x' }], store: [] })
+      json: async () => ({ results: { excel: [{ complaint: 'x' }], store: [] } })
     })
 
   render(<AnalysisForm />)
@@ -119,7 +119,7 @@ test('runs analyze workflow', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ full_text: 'a' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysisText: 'a' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'r' }) })
     .mockResolvedValueOnce({
       ok: true,
@@ -171,7 +171,7 @@ test('shows error alert on empty report response', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ full_text: 'a' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysisText: 'a' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'r' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
 
@@ -222,7 +222,7 @@ test('shows loading indicator during analyze', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockReturnValueOnce(guidePromise)
-    .mockResolvedValueOnce({ ok: true, json: async () => ({ full_text: 't' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysisText: 't' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'r' }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ pdf: '/p', excel: '/e' }) })
 

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -158,16 +158,17 @@ function AnalysisForm({
         return;
       }
       const analysis = await analyzeRes.json();
-      if (!analysis?.full_text) {
+      const text = analysis.full_text || analysis.analysisText;
+      if (!text) {
         setError('Sunucudan beklenmeyen boş yanıt alındı');
         return;
       }
-      setAnalysisText(analysis.full_text);
+      setAnalysisText(text);
 
       const reviewRes = await fetch(`${API_BASE}/review`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: analysis.full_text || JSON.stringify(analysis) })
+        body: JSON.stringify({ text: text || JSON.stringify(analysis) })
       });
       if (!reviewRes.ok) {
         setError(await reviewRes.text());
@@ -225,7 +226,8 @@ function AnalysisForm({
         throw new Error(`HTTP error ${res.status}`);
       }
       const data = await res.json();
-      setClaims(data);
+      const results = data.results || data;
+      setClaims(results);
       setClaimsError('');
     } catch (err) {
       setClaimsError(err.message);


### PR DESCRIPTION
## Summary
- read `analysisText` or `full_text` from `/analyze`
- parse `data.results` from `/complaints`
- update tests for new response keys

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6863e3a2cb88832f85ebeb95baa844a5