### PR TITLE
Switch ComplaintFetcher view to table

### DIFF
--- a/frontend/src/__tests__/ComplaintFetcher.test.jsx
+++ b/frontend/src/__tests__/ComplaintFetcher.test.jsx
@@ -32,8 +32,10 @@ test('fetches complaints and shows data', async () => {
   expect(url).toContain('customer=cust')
   expect(url).toContain('subject=subj')
   expect(url).toContain('part_code=part')
-  await screen.findByText(/"a"/)
-  await screen.findByText(/"b"/)
+  await screen.findByText('a')
+  await screen.findByText('b')
+  const rows = await screen.findAllByRole('row')
+  expect(rows.length).toBeGreaterThan(1)
 })
 
 test('shows error when api fails', async () => {

--- a/frontend/src/components/ComplaintFetcher.jsx
+++ b/frontend/src/components/ComplaintFetcher.jsx
@@ -9,9 +9,14 @@ import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import { API_BASE } from '../api'
 import FileDownloadIcon from '@mui/icons-material/FileDownload'
+import Table from '@mui/material/Table'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import TableCell from '@mui/material/TableCell'
+import TableBody from '@mui/material/TableBody'
 
 function ComplaintFetcher() {
-  const [data, setData] = useState(null)
+  const [rows, setRows] = useState([])
   const [error, setError] = useState(null)
   const [useCustomer, setUseCustomer] = useState(false)
   const [useSubject, setUseSubject] = useState(false)
@@ -39,10 +44,15 @@ function ComplaintFetcher() {
         throw new Error(`HTTP error ${res.status}`)
       }
       const jsonData = await res.json()
-      setData(jsonData)
+      const records = [
+        ...(jsonData.store || []),
+        ...(jsonData.excel || [])
+      ]
+      setRows(records)
       setError(null)
     } catch (err) {
       setError(err.message)
+      setRows([])
     }
   }
 
@@ -110,10 +120,29 @@ function ComplaintFetcher() {
       {error && (
         <Typography color="error" variant="body2">{error}</Typography>
       )}
-      {data && (
-        <pre style={{ whiteSpace: 'pre-wrap' }}>
-          {JSON.stringify(data, null, 2)}
-        </pre>
+      {rows.length > 0 && (
+        <Table size="small" sx={{ mt: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Complaint</TableCell>
+              <TableCell>Customer</TableCell>
+              <TableCell>Subject</TableCell>
+              <TableCell>Part Code</TableCell>
+              <TableCell>Date</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((r, i) => (
+              <TableRow key={i}>
+                <TableCell>{r.complaint}</TableCell>
+                <TableCell>{r.customer}</TableCell>
+                <TableCell>{r.subject}</TableCell>
+                <TableCell>{r.part_code}</TableCell>
+                <TableCell>{r.date}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       )}
     </Box>
   )


### PR DESCRIPTION
## Summary
- display fetched complaints in a Material-UI table
- show combined `store` and `excel` data
- check for table rows in ComplaintFetcher tests

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6863feb69054832fb71805eb274c49db