### PR TITLE
Handle step-based responses in analyze flow

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -161,7 +161,13 @@ function AnalysisForm({
         return;
       }
       const analysis = await analyzeRes.json();
-      const text = analysis.full_text || analysis.analysisText;
+      let text = analysis.full_text || analysis.analysisText;
+      if (!text) {
+        const steps = Object.values(analysis)
+          .map((s) => (s && typeof s === 'object' ? s.response : undefined))
+          .filter(Boolean);
+        text = steps.join('\n\n');
+      }
       if (!text) {
         setRawAnalysis(JSON.stringify(analysis, null, 2));
         setError('Sunucudan beklenmeyen boş yanıt alındı');


### PR DESCRIPTION
## Summary
- combine all step `response` values when `analysisText` or `full_text` are missing
- test fallback behaviour for step-based results

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_686403e7db78832f90f133b8d643a530