### PR TITLE
Add frontend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,12 @@ React tabanli onyuzu calistirmak icin Node.js yüklü olmalidir.
 ```bash
 cd frontend
 npm install
+cp .env.example .env  # API baska bir sunucu veya portta ise URL'yi guncelleyin
 npm run dev
 ```
+Varsayilan ayar API'ye `http://localhost:8000` adresinden baglanir. API farkli
+bir sunucuda veya portta calisiyorsa `.env` dosyasindaki `VITE_API_URL`
+degerini bu adrese gore degistirin.
 
 Balık kılçığı diyagramı için `fishbone-chart` paketini kullanıyoruz.
 `AnalysisForm` bileşeni Ishikawa yöntemi seçildiğinde
@@ -325,8 +329,12 @@ asagidaki komutlari calistirarak gelistirme sunucusunu baslatabilirsiniz:
 ```bash
 cd frontend
 npm install
+cp .env.example .env  # API baska bir sunucu veya portta ise URL'yi guncelleyin
 npm run dev
 ```
+Varsayilan ayar API'ye `http://localhost:8000` adresinden baglanir. API farkli
+bir sunucuda veya portta calisiyorsa `.env` dosyasindaki `VITE_API_URL`
+degerini buna gore degistirin.
 
 ## Masaüstü Uygulama (Electron)
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- include example environment file for the frontend
- document how to use the file and customize `VITE_API_URL`

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6864eabe7a74832f896aa117b272f887