### PR TITLE
Ensure analysis form results reset

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -137,6 +137,9 @@ function AnalysisForm({
     setError('');
     setLoading(true);
     setRawAnalysis('');
+    setAnalysisText('');
+    setReviewText('');
+    setReportPaths(null);
     const details = {
       complaint,
       customer,


### PR DESCRIPTION
## Summary
- reset analysis output state when starting new analysis
- test that handleAnalyze clears old values before running

## Testing
- `python -m unittest discover`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_6864ebb9a1ac832fbe0e0cd6b333b893