### PR TITLE
Fix report path reset on failure

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -190,6 +190,32 @@ test('shows error alert on empty report response', async () => {
   expect(await screen.findByTestId('review-text')).toHaveTextContent('r')
 })
 
+test('hides report links when report request fails', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ fields: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ analysisText: 'a' }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'r' }) })
+    .mockResolvedValueOnce({ ok: false, text: async () => 'err' })
+
+  render(<AnalysisForm initialMethod="8D" />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.change(screen.getByLabelText('Şikayet (Complaint)'), {
+    target: { value: 'c' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'ANALİZ ET' }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(7))
+  const alert = await screen.findAllByRole('alert')
+  expect(alert[1]).toHaveTextContent('err')
+  await screen.findByTestId('analysis-text')
+  await screen.findByTestId('review-text')
+  expect(screen.queryByTestId('pdf-link')).toBeNull()
+})
+
 test('shows alert when analyze request rejects', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -206,6 +206,8 @@ function AnalysisForm({
       });
       if (!reportRes.ok) {
         setError(await reportRes.text());
+        setReportPaths(null);
+        return;
       } else {
         const paths = await reportRes.json();
         if (!paths?.pdf) {


### PR DESCRIPTION
## Summary
- reset report paths when report request fails
- test report path reset on `/report` failure

## Testing
- `python -m unittest discover`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864ed39f298832fa3fdab286f5d2a2b