### PR TITLE
Temporarily disable fishbone feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ Varsayilan ayar API'ye `http://localhost:8000` adresinden baglanir. API farkli
 bir sunucuda veya portta calisiyorsa `.env` dosyasindaki `VITE_API_URL`
 degerini bu adrese gore degistirin.
 
-Balık kılçığı diyagramı için `fishbone-chart` paketini kullanıyoruz.
-`AnalysisForm` bileşeni Ishikawa yöntemi seçildiğinde
-`<FishboneDiagram data={data} />` şeklinde diyagramı gösterir.
+
+> **Not:** Fishbone (Ishikawa) diyagramı özelliği şu anda React 19 ile
+> uyumsuz olan `fishbone-chart` paketine bağlı olduğu için devre dışı
+> bırakılmıştır. Uygun bir çözüm bulunduğunda yeniden etkinleştirilecektir.
 
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "@mui/material": "^7.1.2",
         "@mui/x-date-pickers": "^8.6.0",
         "date-fns": "^4.1.0",
-        "fishbone-chart": "^1.0.24",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "recharts": "^2.9.0"
@@ -3457,21 +3456,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/fishbone-chart": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/fishbone-chart/-/fishbone-chart-1.0.24.tgz",
-      "integrity": "sha512-SOHiVJORUn9wXNxwq6sne8V3EseCZMvNGnyXncPKcaS1Dkzo4VNX146lezY/Ebq/H7uvwwoZjMk03UlN0nrCWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.4",
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/flat-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "fishbone-chart": "^1.0.24",
     "@mui/icons-material": "^7.1.2",
     "@mui/material": "^7.1.2",
     "@mui/x-date-pickers": "^8.6.0",

--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -16,9 +16,6 @@ vi.mock('@mui/material/Autocomplete', () => ({
     )
   }
 }))
-vi.mock('fishbone-chart', () => ({
-  default: () => <div data-testid="fishbone">diagram</div>
-}), { virtual: true })
 
 import AnalysisForm from '../components/AnalysisForm'
 beforeAll(() => {
@@ -102,7 +99,7 @@ test('applies instructionsBoxProps margin', async () => {
   expect(box).toHaveStyle('margin-top: 40px')
 })
 
-test('shows fishbone diagram on Ishikawa method', async () => {
+test.skip('shows fishbone diagram on Ishikawa method', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/__tests__/FishboneDiagram.test.jsx
+++ b/frontend/src/__tests__/FishboneDiagram.test.jsx
@@ -1,13 +1,7 @@
-vi.mock('fishbone-chart', () => ({
-  default: ({ data }) => (
-    <div data-testid="fishbone">{Object.keys(data)[0]}</div>
-  )
-}), { virtual: true })
-
 import { render, screen } from '@testing-library/react'
 import FishboneDiagram from '../components/FishboneDiagram'
 
-it('renders items label', () => {
+test.skip('renders items label', () => {
   const data = { Root: {} }
   render(<FishboneDiagram data={data} />)
   expect(screen.getByTestId('fishbone')).toHaveTextContent('Root')

--- a/frontend/src/components/FishboneDiagram.jsx
+++ b/frontend/src/components/FishboneDiagram.jsx
@@ -1,7 +1,13 @@
-import FishboneChart from 'fishbone-chart';
+// import FishboneChart from 'fishbone-chart';
+
+// Fishbone diagram feature is temporarily disabled due to incompatibility
+// between the `fishbone-chart` package and React 19. Once a compatible
+// solution is available, this component can be restored to render the
+// actual diagram.
 
 function FishboneDiagram({ data }) {
-  return <FishboneChart data={data} />;
+  // Placeholder output while the feature is unavailable
+  return <div>Fishbone diagram feature under construction</div>;
 }
 
 export default FishboneDiagram;


### PR DESCRIPTION
## Summary
- remove `fishbone-chart` from dependencies
- stub out `FishboneDiagram` component
- skip fishbone-related tests
- add note in README about fishbone diagram being unavailable

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: 'dotenv')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6864f0998e9c832f83d5ac65698a6d95