### PR TITLE
Add debugging logs for report generation

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -134,6 +134,7 @@ function AnalysisForm({
     fetchOptions('part_code', setPartCodeOptions);
   }, []);
   const handleAnalyze = async () => {
+    console.log('API_BASE:', API_BASE);
     setError('');
     setLoading(true);
     setRawAnalysis('');
@@ -210,13 +211,17 @@ function AnalysisForm({
         return;
       } else {
         const paths = await reportRes.json();
+        console.log('Backend response paths:', paths);
+        console.log('API_BASE value:', API_BASE);
         if (!paths?.pdf) {
           setError('Sunucudan beklenmeyen boş yanıt alındı');
         } else {
-          setReportPaths({
+          const reportPaths = {
             pdf: `${API_BASE}${paths.pdf}`,
             excel: `${API_BASE}${paths.excel}`,
-          });
+          };
+          console.log('Final report URLs:', reportPaths);
+          setReportPaths(reportPaths);
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- log `API_BASE` at start of `handleAnalyze`
- print backend report paths and final URLs when generating report

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_6864fc14d8a4832fa1a829d887f1cf30