### PR TITLE
Fix blank Electron UI by using relative asset paths

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- set Vite `base` to `./` so built assets use relative paths

## Testing
- `npm test`
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_686523859544832fb8932e36c731765b