### PR TITLE
Add pre-commit and update README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 24.4.2
+  hooks:
+    - id: black
+- repo: https://github.com/pycqa/flake8
+  rev: 7.0.0
+  hooks:
+    - id: flake8
+- repo: local
+  hooks:
+    - id: unit-tests
+      name: python unit tests
+      entry: python -m unittest discover
+      language: system
+      pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ source venv/bin/activate
 
 ```bash
 pip install -r requirements.txt
+pip install pre-commit
 ```
+
+4. Git kancalarini kurmak icin `pre-commit install` komutunu calistirin:
+
+```bash
+pre-commit install
+```
+
+Bu adimlarin ardindan yapacaginiz her commit oncesinde `pre-commit` otomatik
+calisacak ve kodunuzun sekilsel kontrolleri ile birim testleri gerceklestirilecektir.
 
 Bu komut gerekli tüm Python bağımlılıklarını kurar.
 Unicode karakterleri içeren PDF çıktısı alınabilmesi için depo kökünde bulunan
@@ -306,6 +316,13 @@ Bagimliliklari kurduktan sonra birim testlerini asagidaki komutla calistirabilir
 python -m unittest discover
 ```
 
+Kod gondermeden once asagidaki komutla tum kancalari manuel olarak calistirarak
+degisikliklerinizi dogrulayabilirsiniz:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Hizli Test Kurulumu
 
 Testleri calistirmadan once `requirements.txt` dosyasindaki tum paketleri kurmaniz gerektigini unutmayin. Kurulum icin asagidaki betigi veya komutu kullanabilirsiniz:
@@ -319,6 +336,13 @@ Kurulumun ardindan testleri calistirmak icin su komutu kullanin:
 
 ```bash
 python -m unittest discover
+```
+
+Bir commit olusturmadan once `pre-commit` komutu calisarak kod formatinin dogru
+oldugundan ve testlerin gectiginden emin olun:
+
+```bash
+pre-commit
 ```
 
 


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black, flake8 and unit tests
- document how to install and run pre-commit hooks in `README.md`

## Testing
- `python -m unittest discover`
- `pre-commit run --files README.md .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_b_686545d29be0832f89235e35ab2a91af