### PR TITLE
Improve complaints display

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -83,7 +83,7 @@ test('fetches filtered claims', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
   const url = fetch.mock.calls[3][0]
   expect(url).toContain('customer=acme')
-  await screen.findByText(/"x"/)
+  await screen.findByText('x')
 })
 
 test('applies instructionsBoxProps margin', async () => {
@@ -292,14 +292,18 @@ test('shows raw claims json on unexpected response', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({ ok: true, json: async () => ({ strange: true }) })
 
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {})
   render(<AnalysisForm />)
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
 
   fireEvent.click(screen.getByRole('button', { name: /şikayetleri getir/i }))
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
-  const pre = await screen.findByTestId('raw-claims')
-  expect(pre).toHaveTextContent('"strange"')
+  expect(log).toHaveBeenCalledWith(
+    'raw claims',
+    expect.stringContaining('"strange"')
+  )
+  log.mockRestore()
 })
 
 test.skip('uses step responses when analysisText missing', async () => {

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -15,6 +15,12 @@ import {
   MenuItem,
   CircularProgress
 } from '@mui/material';
+import Table from '@mui/material/Table';
+import TableHead from '@mui/material/TableHead';
+import TableBody from '@mui/material/TableBody';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
+import MuiTooltip from '@mui/material/Tooltip';
 import PersonIcon from '@mui/icons-material/Person';
 import LabelIcon from '@mui/icons-material/Label';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
@@ -268,12 +274,18 @@ function AnalysisForm({
         results.store !== undefined ||
         results.excel !== undefined
       ) {
+        const records = Array.isArray(results)
+          ? results
+          : [...(results.store || []), ...(results.excel || [])];
+        console.log('claims data', records);
         setRawClaims('');
-        setClaims(results);
+        setClaims(records);
         setClaimsError('');
       } else {
-        setClaims(null);
-        setRawClaims(JSON.stringify(data, null, 2));
+        setClaims([]);
+        const raw = JSON.stringify(data, null, 2);
+        console.log('raw claims', raw);
+        setRawClaims(raw);
         setClaimsError('');
       }
     } catch (err) {
@@ -560,19 +572,70 @@ function AnalysisForm({
             {claimsError}
           </Alert>
         )}
-        {claims && (
-          <pre style={{ whiteSpace: 'pre-wrap', marginTop: '8px' }}>
-            {JSON.stringify(claims, null, 2)}
-          </pre>
+        {claims && claims.length > 0 && (
+          <Table size="small" sx={{ mt: 2 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell>Tarih</TableCell>
+                <TableCell>Müşteri</TableCell>
+                <TableCell>Şikayet</TableCell>
+                <TableCell>Konu</TableCell>
+                <TableCell>Parça Kodu</TableCell>
+                <TableCell>Açıklama</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {claims.map((c, i) => (
+                <TableRow key={i}>
+                  <TableCell>
+                    {new Date(c.date).toLocaleDateString('tr-TR', {
+                      day: '2-digit',
+                      month: 'long',
+                      year: 'numeric',
+                    })}
+                  </TableCell>
+                  <TableCell>{c.customer}</TableCell>
+                  <TableCell>
+                    <MuiTooltip title={c.complaint || ''}>
+                      <span
+                        style={{
+                          maxWidth: 150,
+                          display: 'inline-block',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {c.complaint}
+                      </span>
+                    </MuiTooltip>
+                  </TableCell>
+                  <TableCell>{c.subject}</TableCell>
+                  <TableCell>{c.part_code}</TableCell>
+                  <TableCell>
+                    <MuiTooltip title={c.description || ''}>
+                      <span
+                        style={{
+                          maxWidth: 150,
+                          display: 'inline-block',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {c.description}
+                      </span>
+                    </MuiTooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         )}
-        {rawClaims && (
-          <pre
-            data-testid="raw-claims"
-            style={{ whiteSpace: 'pre-wrap', marginTop: '8px' }}
-          >
-            {rawClaims}
-          </pre>
+        {claims && claims.length === 0 && (
+          <Typography sx={{ mt: 2 }}>Şikayet bulunamadı</Typography>
         )}
+        {rawClaims && console.log('raw claims', rawClaims)}
         {loading && (
           <Box
             sx={{


### PR DESCRIPTION
## Summary
- render fetched complaints in a Material-UI table
- flatten complaints response in `AnalysisForm`
- log unexpected responses instead of displaying raw JSON
- update tests for new table UI

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_b_68654743948c832fa134728739a32df4