### PR TITLE
Add language selection feature

### DIFF
--- a/LLMAnalyzer/__init__.py
+++ b/LLMAnalyzer/__init__.py
@@ -110,8 +110,21 @@ class LLMAnalyzer:
         details: Dict[str, Any],
         guideline: Dict[str, Any],
         directives: str = "",
+        language: str = "Türkçe",
     ) -> Dict[str, Any]:
-        """Return analysis using complaint details and optional directives."""
+        """Return analysis using complaint details.
+
+        Parameters
+        ----------
+        details
+            Complaint information such as text and customer.
+        guideline
+            Guideline describing the report format.
+        directives
+            Optional user directives to customize the report.
+        language
+            Desired language for the response.
+        """
         complaint_text = details.get("complaint", "")
         customer = details.get("customer", "")
         subject = details.get("subject", "")
@@ -133,6 +146,8 @@ class LLMAnalyzer:
                     f"{directives}\n\n"
                     "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
                 )
+            if language:
+                user_prompt += f"\nRaporu {language} dilinde yaz."
             answer = self._query_llm(DEFAULT_8D_PROMPT, user_prompt)
             return {"full_text": answer}
 
@@ -150,6 +165,8 @@ class LLMAnalyzer:
                     f"{directives}\n\n"
                     "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
                 )
+            if language:
+                user_prompt += f"\nRaporu {language} dilinde yaz."
             answer = self._query_llm("", user_prompt)
             return {"full_text": answer}
 
@@ -193,6 +210,8 @@ class LLMAnalyzer:
                     f"{directives}\n\n"
                     "Lütfen yukarıdaki taleplere ve kısıtlamalara mutlaka uy."
                 )
+            if language:
+                user_prompt += f"\nRaporu {language} dilinde yaz."
 
             answer = self._query_llm(system_prompt, user_prompt)
             results[step_id] = {"response": answer}

--- a/Prompts/Fixer_General_Prompt.md
+++ b/Prompts/Fixer_General_Prompt.md
@@ -1,4 +1,4 @@
 Review the following report for clarity and correctness.
-Return the improved text only.
+Return the improved text only in {language}.
 
 {initial_report_text}

--- a/Review/__init__.py
+++ b/Review/__init__.py
@@ -67,11 +67,16 @@ class Review:
             "part_code": context.get("part_code", ""),
             "initial_report_text": text,
             "guideline_json": context.get("guideline_json", ""),
+            "language": context.get("language", ""),
         }
         return self.template.format(**params)
 
     def perform(self, text: str, **context: str) -> str:
-        """Return a reviewed version of the provided ``text``."""
+        """Return a reviewed version of ``text``.
+
+        ``context`` may include a ``language`` key specifying the desired
+        response language.
+        """
         prompt = self._build_prompt(text, **context)
         return self._query_llm(prompt)
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -44,6 +44,7 @@ class AnalyzeBody(BaseModel):
     details: Dict[str, Any]
     guideline: Dict[str, Any]
     directives: str = ""
+    language: str = "Türkçe"
 
 
 @app.post("/analyze")
@@ -51,7 +52,12 @@ def analyze(body: AnalyzeBody) -> Dict[str, Any]:
     """Return analysis results from ``LLMAnalyzer``."""
     logger.info("Analyze request body: %s", body.dict())
     try:
-        result = analyzer.analyze(body.details, body.guideline, body.directives)
+        result = analyzer.analyze(
+            body.details,
+            body.guideline,
+            body.directives,
+            body.language,
+        )
     except Exception as exc:  # pragma: no cover - unexpected failure
         logger.exception("Analyze failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -99,6 +99,14 @@ function AnalysisForm({
   const [rawClaims, setRawClaims] = useState('');
   const [monthRange, setMonthRange] = useState([0, 11]);
   const [yearRange, setYearRange] = useState([2016, 2025]);
+  const LANGUAGE_OPTIONS = [
+    'Türkçe',
+    'İngilizce',
+    'İtalyanca',
+    'Almanca',
+    'Fransızca'
+  ];
+  const [language, setLanguage] = useState('Türkçe');
   const months = [
     'Oca',
     'Şub',
@@ -167,7 +175,7 @@ function AnalysisForm({
       const analyzeRes = await fetch(`${API_BASE}/analyze`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ details, guideline, directives })
+        body: JSON.stringify({ details, guideline, directives, language })
       });
       if (!analyzeRes.ok) {
         setError(await analyzeRes.text());
@@ -192,7 +200,10 @@ function AnalysisForm({
       const reviewRes = await fetch(`${API_BASE}/review`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: text || JSON.stringify(analysis) })
+        body: JSON.stringify({
+          text: text || JSON.stringify(analysis),
+          context: { language }
+        })
       });
       if (!reviewRes.ok) {
         setError(await reviewRes.text());
@@ -549,12 +560,27 @@ function AnalysisForm({
             display: 'flex',
             gap: 8,
             mt: 'auto',
-			mb: 14,
+                        mb: 14,
             height: '24%',
             minHeight: 60,
             alignItems: 'flex-end'
           }}
         >
+          <Box sx={{ display: 'flex', alignItems: 'center', mr: 2 }}>
+            <Typography sx={{ mr: 1 }}>Dil seçimi</Typography>
+            <Select
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+              size="small"
+              sx={{ minWidth: 120 }}
+            >
+              {LANGUAGE_OPTIONS.map((opt) => (
+                <MenuItem key={opt} value={opt}>
+                  {opt}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
           <Button variant="contained" color="primary" onClick={handleAnalyze}>
             ANALİZ ET
           </Button>
@@ -667,7 +693,7 @@ function AnalysisForm({
             {rawAnalysis}
           </pre>
         )}
-        {analysisText && (
+        {analysisText && !reviewText && (
           <Box sx={{ mt: 2 }}>
             <Card variant="outlined" sx={{ p: 2, backgroundColor: '#f9f9f9' }}>
               <Typography data-testid="analysis-text" sx={{ whiteSpace: 'pre-line' }}>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,15 +29,30 @@ class APITest(unittest.TestCase):
         self.assertIn("access-control-allow-origin", response.headers)
 
     def test_analyze_endpoint(self) -> None:
-        payload = {"details": {"complaint": "c"}, "guideline": {"fields": []}, "directives": ""}
+        payload = {
+            "details": {"complaint": "c"},
+            "guideline": {"fields": []},
+            "directives": "",
+            "language": "Türkçe",
+        }
         with patch.object(api.analyzer, "analyze", return_value={"ok": 1}) as mock_analyze:
             response = self.client.post("/analyze", json=payload)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"ok": 1})
-        mock_analyze.assert_called_with(payload["details"], payload["guideline"], "")
+        mock_analyze.assert_called_with(
+            payload["details"],
+            payload["guideline"],
+            "",
+            "Türkçe",
+        )
 
     def test_analyze_logging(self) -> None:
-        payload = {"details": {"complaint": "c"}, "guideline": {"fields": []}, "directives": ""}
+        payload = {
+            "details": {"complaint": "c"},
+            "guideline": {"fields": []},
+            "directives": "",
+            "language": "Türkçe",
+        }
         with patch.object(api.analyzer, "analyze", return_value={"ok": 1}):
             with self.assertLogs("api", level="INFO") as cm:
                 response = self.client.post("/analyze", json=payload)
@@ -47,7 +62,12 @@ class APITest(unittest.TestCase):
         self.assertIn("Analyze result", logs)
 
     def test_analyze_endpoint_error(self) -> None:
-        payload = {"details": {}, "guideline": {}, "directives": ""}
+        payload = {
+            "details": {},
+            "guideline": {},
+            "directives": "",
+            "language": "Türkçe",
+        }
         with patch.object(api.analyzer, "analyze", side_effect=OpenAIError("fail")):
             response = self.client.post("/analyze", json=payload)
         self.assertEqual(response.status_code, 500)

--- a/tests/test_llm_analyzer.py
+++ b/tests/test_llm_analyzer.py
@@ -76,6 +76,15 @@ class LLMAnalyzerTest(unittest.TestCase):
         call_args = mock_query.call_args[0]
         self.assertIn("Kullanıcıdan gelen özel talimatlar:\nd", call_args[1])
 
+    @patch.object(LLMAnalyzer, "_query_llm", return_value="ok")
+    def test_language_added_to_prompt(self, mock_query) -> None:  # type: ignore
+        """Selected language should be included in the prompt."""
+        guideline = {"method": "A3", "fields": []}
+        details = {"complaint": "c"}
+        self.analyzer.analyze(details, guideline, language="İngilizce")
+        call_args = mock_query.call_args[0]
+        self.assertIn("İngilizce", call_args[1])
+
     def test_query_llm_fallback(self) -> None:
         """``_query_llm`` should return a placeholder for non-auth errors."""
         mock_openai = types.ModuleType("openai")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -21,7 +21,7 @@ class ReviewTest(unittest.TestCase):
             review = Review()
         with patch.object(Review, "_query_llm") as mock_query:
             mock_query.return_value = "ok"
-            review.perform("data")
+            review.perform("data", language="Türkçe")
             mock_query.assert_called_with("prefix data suffix")
 
     def test_query_llm_logs_error(self) -> None:


### PR DESCRIPTION
## Summary
- add `language` parameter to analyzer and review
- update prompts to include language placeholder
- include language in API and React frontend
- show report only once using reviewed text
- test coverage for new language option

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_b_68658b93e8a8832f8afb317d99ac0c25