### PR TITLE
Add report guide modal

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -142,6 +142,28 @@ test.skip('runs analyze workflow', async () => {
   await screen.findByTestId('excel-link')
 })
 
+test('opens and closes report guide modal', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.click(screen.getByRole('button', { name: /rapor kılavuzu/i }))
+  expect(
+    screen.getByText(/Rapor Kılavuzu – Kaliteli ve Anlamlı Çıktı İçin İpuçları/i)
+  ).toBeInTheDocument()
+
+  fireEvent.click(screen.getByLabelText(/close/i))
+  await waitFor(() =>
+    expect(
+      screen.queryByText(/Rapor Kılavuzu – Kaliteli ve Anlamlı Çıktı İçin İpuçları/i)
+    ).toBeNull()
+  )
+})
+
 test('shows error alert on analyze failure', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -28,6 +28,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import DescriptionIcon from '@mui/icons-material/Description';
 import FishboneDiagram from './FishboneDiagram';
+import ReportGuideModal from './ReportGuideModal';
 import {
   ResponsiveContainer,
   BarChart,
@@ -107,6 +108,7 @@ function AnalysisForm({
     'Fransızca'
   ];
   const [language, setLanguage] = useState('Türkçe');
+  const [guideOpen, setGuideOpen] = useState(false);
   const months = [
     'Oca',
     'Şub',
@@ -309,6 +311,7 @@ function AnalysisForm({
   console.log('reviewText:', reviewText);
   console.log('reportPaths:', reportPaths);
   return (
+    <>
     <Card
       sx={{
         width: 1600,
@@ -581,6 +584,13 @@ function AnalysisForm({
               ))}
             </Select>
           </Box>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => setGuideOpen(true)}
+          >
+            Rapor Kılavuzu
+          </Button>
           <Button variant="contained" color="primary" onClick={handleAnalyze}>
             ANALİZ ET
           </Button>
@@ -826,6 +836,8 @@ function AnalysisForm({
         </Box>
       </Box>
     </Card>
+    <ReportGuideModal open={guideOpen} onClose={() => setGuideOpen(false)} />
+    </>
   );
 }
 export default AnalysisForm;

--- a/frontend/src/components/ReportGuideModal.jsx
+++ b/frontend/src/components/ReportGuideModal.jsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Modal, Box, Typography, IconButton } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+
+function ReportGuideModal({ open, onClose }) {
+  return (
+    <Modal open={open} onClose={onClose} aria-labelledby="report-guide-title">
+      <Box
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          bgcolor: 'background.paper',
+          boxShadow: 24,
+          p: 3,
+          borderRadius: 2,
+          maxWidth: 600,
+          width: '90%',
+          maxHeight: '80%',
+          overflowY: 'auto',
+        }}
+      >
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{ position: 'absolute', top: 8, right: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <Typography id="report-guide-title" variant="h6" sx={{ mb: 2 }}>
+          Rapor Kılavuzu – Kaliteli ve Anlamlı Çıktı İçin İpuçları
+        </Typography>
+        <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 1 }}>
+          a) Kısa Şikayetler, Yüzeysel Rapor:
+        </Typography>
+        <Typography variant="body2" paragraph>
+          Eğer çok kısa şekilde şikayet yazarsanız (örneğin “kaynak kopması”, “parçada çapak”)
+          oluşan rapor çok genel ve yüzeysel olacaktır. Yapay zeka asistanına parça ve problem
+          ile ilgili ne kadar detay verirseniz, o kadar iyi ve size özel bir çıktı alabilirsiniz.
+        </Typography>
+        <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
+          b) Departman ve Ünvanları Özelleştirin:
+        </Typography>
+        <Typography variant="body2" paragraph>
+          Yapay zeka raporu oluştururken işletmenizin yapısını ve departman isimlerini net olarak
+          bilemez. Raporda olmasını ya da olmamasını istediğiniz departman isimlerini ya da
+          ünvanları “Özel Şartlar” kısmına ekleyerek yönetebilirsiniz.
+        </Typography>
+        <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
+          c) Özel Şartlar Her Zaman Göz Önünde:
+        </Typography>
+        <Typography variant="body2" paragraph>
+          Özel Şartlar bölümüne yazacağınız her kelime, doğrudan yapay zekâya talimat olarak
+          gönderilir ve rapor oluşturulurken dikkate alınır.
+        </Typography>
+        <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
+          Ekstra İpuçları:
+        </Typography>
+        <Typography variant="body2" component="div">
+          <ul>
+            <li>Somut Olaylar Yazın: Şikayetinizi örnekle açıklayın. (Ör: “25 Mayıs’ta 5 adet ürünün bağlantı noktasında çatlak tespit edildi, numuneler ekte.”)</li>
+            <li>Beklediğiniz Sonuçları Netleştirin: Raporda yer almasını istediğiniz özel iyileştirme adımlarını veya önlemleri belirtin.</li>
+            <li>Teknik Terim ve Kısaltmalara Dikkat: Varsa açıklamalarını ekleyin, yanlış yönlendirmeleri önleyin.</li>
+            <li>İstenmeyen Bölümleri Belirtin: Raporda istemediğiniz, gereksiz bulduğunuz başlıkları “Özel Şartlar”a ekleyerek hariç tutabilirsiniz.</li>
+          </ul>
+        </Typography>
+      </Box>
+    </Modal>
+  )
+}
+
+export default ReportGuideModal


### PR DESCRIPTION
## Summary
- show a new "Rapor Kılavuzu" modal in AnalysisForm
- support opening and closing the guide
- test the new modal behaviour

## Testing
- `npm install`
- `npx vitest run --silent` *(fails: Unable to find an element by: [data-testid="analysis-text"])*

------
https://chatgpt.com/codex/tasks/task_b_686590d0df78832fa58c007a5a51c1d3