### PR TITLE
Refactor complaints filter handling

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -108,27 +108,18 @@ def report(body: ReportBody) -> Dict[str, str]:
 @app.get("/complaints")
 def complaints(
     request: Request,
-    keyword: Optional[str] = None,
-    complaint: Optional[str] = None,
-    customer: Optional[str] = None,
-    subject: Optional[str] = None,
-    part_code: Optional[str] = None,
     year: Optional[int] = None,
     start_year: Optional[int] = None,
     end_year: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Return complaint queries from JSON store and Excel file."""
     logger.info("Complaints query params: %s", request.query_params)
+    keyword = request.query_params.get("keyword")
     store_results = _store.search(keyword) if keyword else []
-    filters: Dict[str, str] = {}
-    if complaint:
-        filters["complaint"] = complaint
-    if customer:
-        filters["customer"] = customer
-    if subject:
-        filters["subject"] = subject
-    if part_code:
-        filters["part_code"] = part_code
+    known = {"keyword", "year", "start_year", "end_year"}
+    filters: Dict[str, str] = {
+        k: v for k, v in request.query_params.items() if k not in known
+    }
     excel_results = []
     if filters or year is not None or start_year is not None or end_year is not None:
         excel_results = _excel_searcher.search(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,9 +114,10 @@ class APITest(unittest.TestCase):
             tmp_file.unlink()
 
     def test_complaints_endpoint(self) -> None:
+        params = {"keyword": "k", "customer": "c"}
         with patch.object(api._store, "search", return_value=[{"id": 1}]) as mock_store, \
              patch.object(api._excel_searcher, "search", return_value=[{"id": 2}]) as mock_excel:
-            response = self.client.get("/complaints", params={"keyword": "k", "customer": "c"})
+            response = self.client.get("/complaints", params=params)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"store": [{"id": 1}], "excel": [{"id": 2}]})
         mock_store.assert_called_with("k")
@@ -128,6 +129,15 @@ class APITest(unittest.TestCase):
             response = self.client.get("/complaints", params=params)
         self.assertEqual(response.status_code, 200)
         mock_excel.assert_called_with({"customer": "c"}, None, start_year=2020, end_year=2022)
+
+    def test_complaints_extra_filters_forwarded(self) -> None:
+        params = {"foo": "bar", "customer": "c"}
+        with patch.object(api._store, "search") as mock_store, \
+             patch.object(api._excel_searcher, "search", return_value=[]) as mock_excel:
+            response = self.client.get("/complaints", params=params)
+        self.assertEqual(response.status_code, 200)
+        mock_store.assert_not_called()
+        mock_excel.assert_called_with({"foo": "bar", "customer": "c"}, None, start_year=None, end_year=None)
 
     def test_options_endpoint(self) -> None:
         with patch.object(


### PR DESCRIPTION
## Summary
- simplify `/complaints` endpoint parameters
- parse filters from request query params and pass them unchanged
- test forwarding of arbitrary query parameters

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6866286abd80832f8ec5c1e070e67086