### PR TITLE
Dynamic column rendering for complaint tables

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -68,7 +68,9 @@ test('fetches filtered claims', async () => {
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
     .mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ results: { excel: [{ complaint: 'x' }], store: [] } })
+      json: async () => ({
+        results: { excel: [{ complaint: 'x', customer: 'y' }], store: [] }
+      })
     })
 
   render(<AnalysisForm />)
@@ -84,6 +86,10 @@ test('fetches filtered claims', async () => {
   const url = fetch.mock.calls[3][0]
   expect(url).toContain('customer=acme')
   await screen.findByText('x')
+  const headers = screen
+    .getAllByRole('columnheader')
+    .map((h) => h.textContent)
+  expect(headers).toEqual(expect.arrayContaining(['complaint', 'customer']))
 })
 
 test('applies instructionsBoxProps margin', async () => {

--- a/frontend/src/__tests__/ComplaintFetcher.test.jsx
+++ b/frontend/src/__tests__/ComplaintFetcher.test.jsx
@@ -12,7 +12,10 @@ afterEach(() => {
 test('fetches complaints and shows data', async () => {
   fetch.mockResolvedValueOnce({
     ok: true,
-    json: async () => ({ store: [{ complaint: 'a' }], excel: [{ complaint: 'b' }] })
+    json: async () => ({
+      store: [{ complaint: 'a', customer: 'one' }],
+      excel: [{ complaint: 'b', customer: 'two' }]
+    })
   })
 
   render(<ComplaintFetcher />)
@@ -34,6 +37,8 @@ test('fetches complaints and shows data', async () => {
   expect(url).toContain('part_code=part')
   await screen.findByText('a')
   await screen.findByText('b')
+  const headers = screen.getAllByRole('columnheader').map((h) => h.textContent)
+  expect(headers).toEqual(expect.arrayContaining(['complaint', 'customer']))
   const rows = await screen.findAllByRole('row')
   expect(rows.length).toBeGreaterThan(1)
 })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -609,64 +609,40 @@ function AnalysisForm({
           </Alert>
         )}
         {claims && claims.length > 0 && (
-          <Table size="small" sx={{ mt: 2 }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>Tarih</TableCell>
-                <TableCell>Müşteri</TableCell>
-                <TableCell>Şikayet</TableCell>
-                <TableCell>Konu</TableCell>
-                <TableCell>Parça Kodu</TableCell>
-                <TableCell>Açıklama</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {claims.map((c, i) => (
-                <TableRow key={i}>
-                  <TableCell>
-                    {new Date(c.date).toLocaleDateString('tr-TR', {
-                      day: '2-digit',
-                      month: 'long',
-                      year: 'numeric',
-                    })}
-                  </TableCell>
-                  <TableCell>{c.customer}</TableCell>
-                  <TableCell>
-                    <MuiTooltip title={c.complaint || ''}>
-                      <span
-                        style={{
-                          maxWidth: 150,
-                          display: 'inline-block',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {c.complaint}
-                      </span>
-                    </MuiTooltip>
-                  </TableCell>
-                  <TableCell>{c.subject}</TableCell>
-                  <TableCell>{c.part_code}</TableCell>
-                  <TableCell>
-                    <MuiTooltip title={c.description || ''}>
-                      <span
-                        style={{
-                          maxWidth: 150,
-                          display: 'inline-block',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {c.description}
-                      </span>
-                    </MuiTooltip>
-                  </TableCell>
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table size="small" sx={{ mt: 2 }}>
+              <TableHead>
+                <TableRow>
+                  {Object.keys(claims[0]).map((col) => (
+                    <TableCell key={col}>
+                      <MuiTooltip title={col} placement="top">
+                        <span
+                          style={{
+                            maxWidth: 120,
+                            display: 'inline-block',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {col}
+                        </span>
+                      </MuiTooltip>
+                    </TableCell>
+                  ))}
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHead>
+              <TableBody>
+                {claims.map((c, i) => (
+                  <TableRow key={i}>
+                    {Object.keys(claims[0]).map((col) => (
+                      <TableCell key={col}>{c[col]}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Box>
         )}
         {claims && claims.length === 0 && (
           <Typography sx={{ mt: 2 }}>Şikayet bulunamadı</Typography>

--- a/frontend/src/components/ComplaintFetcher.jsx
+++ b/frontend/src/components/ComplaintFetcher.jsx
@@ -14,6 +14,7 @@ import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import TableCell from '@mui/material/TableCell'
 import TableBody from '@mui/material/TableBody'
+import Tooltip from '@mui/material/Tooltip'
 
 function ComplaintFetcher() {
   const [rows, setRows] = useState([])
@@ -121,28 +122,40 @@ function ComplaintFetcher() {
         <Typography color="error" variant="body2">{error}</Typography>
       )}
       {rows.length > 0 && (
-        <Table size="small" sx={{ mt: 2 }}>
-          <TableHead>
-            <TableRow>
-              <TableCell>Complaint</TableCell>
-              <TableCell>Customer</TableCell>
-              <TableCell>Subject</TableCell>
-              <TableCell>Part Code</TableCell>
-              <TableCell>Date</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((r, i) => (
-              <TableRow key={i}>
-                <TableCell>{r.complaint}</TableCell>
-                <TableCell>{r.customer}</TableCell>
-                <TableCell>{r.subject}</TableCell>
-                <TableCell>{r.part_code}</TableCell>
-                <TableCell>{r.date}</TableCell>
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small" sx={{ mt: 2 }}>
+            <TableHead>
+              <TableRow>
+                {Object.keys(rows[0]).map((col) => (
+                  <TableCell key={col}>
+                    <Tooltip title={col} placement="top">
+                      <span
+                        style={{
+                          maxWidth: 120,
+                          display: 'inline-block',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap'
+                        }}
+                      >
+                        {col}
+                      </span>
+                    </Tooltip>
+                  </TableCell>
+                ))}
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {rows.map((r, i) => (
+                <TableRow key={i}>
+                  {Object.keys(rows[0]).map((col) => (
+                    <TableCell key={col}>{r[col]}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
       )}
     </Box>
   )


### PR DESCRIPTION
## Summary
- render complaint data tables dynamically based on fetched keys
- apply ellipsis styling with tooltip for long labels
- update ComplaintFetcher and AnalysisForm tests for dynamic columns

## Testing
- `npx vitest run` *(fails: 2 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68662a862824832fb077d5f5e0ca562f