### PR TITLE
Update default claims path

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -24,14 +24,16 @@ class ExcelClaimsSearcher:
         """Initialize with optional Excel file ``path``.
 
         When ``path`` is ``None``, ``CLAIMS_FILE_PATH`` is read from the
-        ``.env`` file. If the variable is unset, the bundled ``claims.xlsx``
-        inside the ``CC`` package is used.
+        ``.env`` file. If the variable is unset, the bundled
+        ``F160_Customer_Claims.xlsx`` inside the ``CC`` package is used.
         """
         if path is None:
             load_dotenv()
             path = os.getenv("CLAIMS_FILE_PATH")
             if path is None:
-                path = resources.files("CC").joinpath("claims.xlsx")
+                path = resources.files("CC").joinpath(
+                    "F160_Customer_Claims.xlsx"
+                )
         self.path = Path(path)
 
     def _load_headers(

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ export OPENAI_API_KEY="sk-..."
 
 Anahtari ve sikayet kaydi Excel dosyasinin yolunu kolayca tanimlamak icin
 `configure_env.py` betigini calistirabilirsiniz. Betik istenen bilgileri
-sorarak `.env` dosyasina yazar.
+sorarak `.env` dosyasina yazar. Varsayilan ornek dosya
+``CC/F160_Customer_Claims.xlsx`` konumunda bulunur.
 
 ```bash
 python configure_env.py

--- a/configure_env.py
+++ b/configure_env.py
@@ -12,7 +12,7 @@ ENV_PATH = Path(".env")
 def main() -> None:
     """Prompt for configuration values and store them in ``.env``."""
     api_key = input("OpenAI API key: ").strip()
-    claims_path = input("Path to claims.xlsx: ").strip()
+    claims_path = input("Path to F160_Customer_Claims.xlsx: ").strip()
     model_choice = input(
         "OpenAI Model (1: gpt-4o, 2: gpt-4o-mini, 3: gpt-4-turbo, 4: gpt-3.5-turbo): "
     ).strip()

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -127,7 +127,7 @@ class ExcelClaimsSearchTest(unittest.TestCase):
     def test_bundled_file_outside_repo(self) -> None:
         """Bundled Excel file should load when run outside the repo root."""
         repo_root = Path(__file__).resolve().parents[1]
-        expected = repo_root / "CC" / "claims.xlsx"
+        expected = repo_root / "CC" / "F160_Customer_Claims.xlsx"
         with tempfile.TemporaryDirectory() as tmpdir:
             cwd = os.getcwd()
             try:


### PR DESCRIPTION
## Summary
- default to `CC/F160_Customer_Claims.xlsx` in `ExcelClaimsSearcher`
- prompt for the same path in `configure_env.py`
- mention the bundled file in the README
- adjust tests for the new bundled path

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_b_68662cc62638832fae2bd9c2504c2ab7