### PR TITLE
Handle Turkish alias in complaints

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 ALIAS_TO_HEADER = {
     normalize_text("customer"): "Müşteri Adı",
     normalize_text("musteri"): "Müşteri Adı",
+    normalize_text("müşteri adı"): "Müşteri Adı",
     normalize_text("musteri adi"): "Müşteri Adı",
     normalize_text("subject"): "Hata Tanımı - Kök Neden",
     normalize_text("konu"): "Konu",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,6 +139,13 @@ class APITest(unittest.TestCase):
         mock_store.assert_not_called()
         mock_excel.assert_called_with({"foo": "bar", "Müşteri Adı": "c"}, None, start_year=None, end_year=None)
 
+    def test_complaints_alias_turkish_key(self) -> None:
+        params = {"Müşteri Adı": "c"}
+        with patch.object(api._excel_searcher, "search", return_value=[]) as mock_excel:
+            response = self.client.get("/complaints", params=params)
+        self.assertEqual(response.status_code, 200)
+        mock_excel.assert_called_with({"Müşteri Adı": "c"}, None, start_year=None, end_year=None)
+
     def test_options_endpoint(self) -> None:
         with patch.object(
             api._excel_searcher,


### PR DESCRIPTION
## Summary
- support `Müşteri Adı` alias by adding `normalize_text("müşteri adı")` entry
- cover the alias handling in the complaints API tests

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68665ec298c8832fb2a3e555fbe8362e