### PR TITLE
Handle empty claims gracefully

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -112,6 +112,25 @@ test('shows alert on claims fetch rejection', async () => {
   expect(await screen.findByText('claims fail')).toBeInTheDocument()
 })
 
+test('renders placeholder table when no claims returned', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ results: { excel: [], store: [] } }) })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.click(screen.getByRole('button', { name: /şikayetleri getir/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+
+  const rows = screen.getAllByRole('row', { hidden: true })
+  const placeholderRow = rows.find((r) => r.classList.contains('placeholder-row'))
+  expect(placeholderRow).toBeDefined()
+})
+
 test('applies instructionsBoxProps margin', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -94,7 +94,7 @@ function AnalysisForm({
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: 10 }, (_, i) => `${currentYear - i}`);
   const [selectedYear, setSelectedYear] = useState('');
-  const [claims, setClaims] = useState(null);
+  const [claims, setClaims] = useState([]);
   const [claimsError, setClaimsError] = useState('');
   const [error, setError] = useState('');
   const [reviewText, setReviewText] = useState('');
@@ -115,6 +115,13 @@ function AnalysisForm({
   ];
   const [language, setLanguage] = useState('Türkçe');
   const [guideOpen, setGuideOpen] = useState(false);
+  const PLACEHOLDER_CLAIMS = [
+    {
+      complaint: 'placeholder',
+      customer: 'placeholder',
+      part_code: '0000'
+    }
+  ];
   const months = [
     'Oca',
     'Şub',
@@ -633,12 +640,14 @@ function AnalysisForm({
             {claimsError}
           </Alert>
         )}
-        {claims && claims.length > 0 && (
+        {(claims && claims.length >= 0) && (
           <Box sx={{ overflowX: 'auto' }}>
             <Table size="small" sx={{ mt: 2 }}>
               <TableHead>
                 <TableRow>
-                  {Object.keys(claims[0]).map((col) => (
+                  {Object.keys(
+                    (claims && claims.length > 0 ? claims : PLACEHOLDER_CLAIMS)[0]
+                  ).map((col) => (
                     <TableCell key={col}>
                       <MuiTooltip title={col} placement="top">
                         <span
@@ -658,13 +667,25 @@ function AnalysisForm({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {claims.map((c, i) => (
-                  <TableRow key={i}>
-                    {Object.keys(claims[0]).map((col) => (
-                      <TableCell key={col}>{c[col]}</TableCell>
-                    ))}
-                  </TableRow>
-                ))}
+                {(claims && claims.length > 0 ? claims : PLACEHOLDER_CLAIMS).map(
+                  (c, i) => (
+                    <TableRow
+                      key={i}
+                      data-placeholder={claims && claims.length > 0 ? undefined : true}
+                      className={
+                        claims && claims.length > 0 ? undefined : 'placeholder-row'
+                      }
+                    >
+                      {Object.keys(
+                        (claims && claims.length > 0
+                          ? claims
+                          : PLACEHOLDER_CLAIMS)[0]
+                      ).map((col) => (
+                        <TableCell key={col}>{c[col]}</TableCell>
+                      ))}
+                    </TableRow>
+                  )
+                )}
               </TableBody>
             </Table>
           </Box>


### PR DESCRIPTION
## Summary
- default `claims` to an empty array
- render a placeholder table when no claims returned
- mark placeholder rows for testing
- add unit test for placeholder rendering

## Testing
- `python -m unittest discover`
- `npm test --silent` *(fails: watch mode runs indefinitely until interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_686687e07a10832f8de8496d50e32c33