### PR TITLE
Fix options mapping and update logging config

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -176,7 +176,8 @@ def add_complaint(body: ComplaintBody) -> Dict[str, str]:
 def options(field: str, request: Request) -> Dict[str, Any]:
     """Return unique option values for ``field`` from the Excel claims file."""
     logger.info("Options query params: %s", request.query_params)
-    result = {"values": _excel_searcher.unique_values(field)}
+    mapped_field = ALIAS_TO_HEADER.get(normalize_text(field), field)
+    result = {"values": _excel_searcher.unique_values(mapped_field)}
     logger.info("Options result: %s", result)
     return result
 

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -9,8 +9,11 @@ __all__ = ["configure_logging"]
 
 
 def configure_logging() -> None:
-    """Initialize basic logging if no handlers are present."""
-    if not logging.getLogger().handlers:
+    """Initialize basic logging if no user handlers are present."""
+    root = logging.getLogger()
+    ignore = {"LogCaptureHandler", "_LiveLoggingNullHandler", "_FileHandler"}
+    has_real = any(h.__class__.__name__ not in ignore for h in root.handlers)
+    if not has_real:
         level_name = os.getenv("LOG_LEVEL", "INFO").upper()
         level = getattr(logging, level_name, logging.INFO)
         logging.basicConfig(level=level)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,7 +155,7 @@ class APITest(unittest.TestCase):
             response = self.client.get("/options/customer")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"values": ["a", "b"]})
-        mock_opts.assert_called_with("customer")
+        mock_opts.assert_called_with("Müşteri Adı")
 
     def test_guide_endpoint(self) -> None:
         with patch.object(


### PR DESCRIPTION
## Summary
- map `/options/{field}` parameter through alias mapping
- adjust test expectations
- ignore pytest log handlers in `configure_logging`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_686697738a84832fb9796b416efb9288