### PR TITLE
Add claim debug logs and tests

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -94,6 +94,10 @@ test('fetches filtered claims', async () => {
   expect(
     screen.getByText(/Fetched 1 claims/)
   ).toBeInTheDocument()
+  expect(screen.getByTestId('claims-json')).toHaveTextContent('"x"')
+  expect(screen.getByTestId('claim-columns')).toHaveTextContent(
+    'complaint, customer'
+  )
 })
 
 test('shows alert on claims fetch rejection', async () => {

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -315,6 +315,7 @@ function AnalysisForm({
         console.log('claims data', records);
         setRawClaims('');
         setClaims(records);
+        console.log(records);
         setClaimsError('');
         setDebugMessages((m) => [...m, `Fetched ${records.length} claims`]);
       } else {
@@ -335,6 +336,7 @@ function AnalysisForm({
   console.log('analysisText:', analysisText);
   console.log('reviewText:', reviewText);
   console.log('reportPaths:', reportPaths);
+  console.log('columns', Object.keys(claims?.[0] || {}));
   return (
     <>
     <Card
@@ -688,6 +690,10 @@ function AnalysisForm({
                 )}
               </TableBody>
             </Table>
+            <pre data-testid="claims-json">{JSON.stringify(claims)}</pre>
+            <div data-testid="claim-columns">
+              {Object.keys(claims[0] || {}).join(', ')}
+            </div>
           </Box>
         )}
         {claims && claims.length === 0 && (
@@ -858,6 +864,8 @@ function AnalysisForm({
         </Box>
       </Box>
     </Card>
+    <div>ALAKASIZ TEST YAZISI</div>
+    <p>{Math.random()}</p>
     <ReportGuideModal open={guideOpen} onClose={() => setGuideOpen(false)} />
     </>
   );


### PR DESCRIPTION
## Summary
- log fetched claims and claim columns in `AnalysisForm`
- display JSON of fetched claims and column names in the UI
- add extra random UI elements
- test that new debug outputs appear when claims are fetched

## Testing
- `npm test --silent`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6866e657ef7c832f8ca95e5fcd7efd82