### PR TITLE
Ensure AnalysisForm shows placeholder rows after failed fetch

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -114,6 +114,10 @@ test('shows alert on claims fetch rejection', async () => {
 
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
   expect(await screen.findByText('claims fail')).toBeInTheDocument()
+
+  const rows = screen.getAllByRole('row', { hidden: true })
+  const placeholderRow = rows.find((r) => r.classList.contains('placeholder-row'))
+  expect(placeholderRow).toBeDefined()
 })
 
 test('renders placeholder table when no claims returned', async () => {

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -329,7 +329,7 @@ function AnalysisForm({
     } catch (err) {
       console.error(err);
       setClaimsError(err.message || 'Şikayetler alınamadı');
-      setClaims(null);
+      setClaims([]);
       setRawClaims('');
     }
   };


### PR DESCRIPTION
## Summary
- fix `handleFetchClaims` so failed fetches reset claims to an empty array
- verify placeholder row still renders even when the fetch fails

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6866e7d1ed4c832fbd717c6baf8142e6