### PR TITLE
Fix table height and style

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -385,7 +385,7 @@ function AnalysisForm({
         sx={{
           width: '68%',
           minWidth: 0,
-          height: { xs: 'auto', md: 540 },
+          height: 'auto',
           display: 'flex',
           flexDirection: 'column',
           pr: 3,
@@ -664,7 +664,10 @@ function AnalysisForm({
         )}
         {(claims && claims.length > 0) && (
           <Box sx={{ overflowX: 'auto' }}>
-            <Table size="small" sx={{ mt: 2 }}>
+            <Table
+              size="small"
+              sx={{ mt: 2, backgroundColor: '#fff', border: '1px solid #ccc' }}
+            >
               <TableHead>
                 <TableRow>
                   {Object.keys(


### PR DESCRIPTION
## Summary
- allow the left pane to grow so tables are visible
- give the main table a visible background and border

## Testing
- `npm test --silent` *(fails: vitest tests do not all pass)*
- `python -m unittest discover` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686836f950c8832fb31dc627e8ec05c9