### PR TITLE
Prettify claim table headers

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -90,13 +90,13 @@ test('fetches filtered claims', async () => {
   const headers = screen
     .getAllByRole('columnheader')
     .map((h) => h.textContent)
-  expect(headers).toEqual(expect.arrayContaining(['complaint', 'customer']))
+  expect(headers).toEqual(expect.arrayContaining(['Complaint', 'Customer']))
   expect(
     screen.getByText(/Fetched 1 claims/)
   ).toBeInTheDocument()
   expect(screen.getByTestId('claims-json')).toHaveTextContent('"x"')
   expect(screen.getByTestId('claim-columns')).toHaveTextContent(
-    'complaint, customer'
+    'Complaint, Customer'
   )
 })
 
@@ -120,7 +120,7 @@ test('handles single claim object response', async () => {
   const headers = screen
     .getAllByRole('columnheader')
     .map((h) => h.textContent)
-  expect(headers).toEqual(expect.arrayContaining(['complaint', 'customer']))
+  expect(headers).toEqual(expect.arrayContaining(['Complaint', 'Customer']))
   await screen.findByText('x')
   await screen.findByText('y')
   expect(screen.getByText(/Fetched 1 claims/)).toBeInTheDocument()

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -39,6 +39,14 @@ import {
   CartesianGrid
 } from 'recharts';
 import { API_BASE } from '../api';
+
+function prettify(str) {
+  return str
+    .replace(/_/g, ' ')
+    .split(' ')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}
 const FIELD_MAP = {
   customer: 'Müşteri Adı',
   subject: 'Hata Tanımı - Kök Neden',
@@ -613,7 +621,7 @@ function AnalysisForm({
                             whiteSpace: 'nowrap',
                           }}
                         >
-                          {col}
+                          {prettify(col)}
                         </span>
                       </MuiTooltip>
                     </TableCell>


### PR DESCRIPTION
## Summary
- add a `prettify` helper for table headers in `AnalysisForm`
- use `prettify` to display title-cased column names
- adjust AnalysisForm tests for new header text

## Testing
- `python -m unittest discover`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868551cec60832fa1ccb473a2f9e81d