### PR TITLE
Handle ISO dates in claims table

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -126,6 +126,27 @@ test('handles single claim object response', async () => {
   expect(screen.getByText(/Fetched 1 claims/)).toBeInTheDocument()
 })
 
+test('formats iso date strings in claims table', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: { excel: [{ when: '2024-01-24T00:00:00' }], store: [] }
+      })
+    })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.click(screen.getByRole('button', { name: /şikayetleri getir/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+  await screen.findByText('2024-01-24')
+})
+
 test('shows alert on claims fetch rejection', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -47,6 +47,13 @@ function prettify(str) {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
     .join(' ');
 }
+
+function formatDate(value) {
+  if (typeof value === 'string' && /\d{4}-\d{2}-\d{2}T00:00:00/.test(value)) {
+    return value.replace(/T00:00:00.*$/, '');
+  }
+  return value;
+}
 const FIELD_MAP = {
   customer: 'Müşteri Adı',
   subject: 'Hata Tanımı - Kök Neden',
@@ -643,7 +650,7 @@ function AnalysisForm({
                           ? claims
                           : PLACEHOLDER_CLAIMS)[0]
                       ).map((col) => (
-                        <TableCell key={col}>{c[col]}</TableCell>
+                        <TableCell key={col}>{formatDate(c[col])}</TableCell>
                       ))}
                     </TableRow>
                   )


### PR DESCRIPTION
## Summary
- add `formatDate` helper
- display formatted dates when rendering claims
- test that ISO dates are shown without the time portion

## Testing
- `python -m unittest discover`
- `npx vitest run src/__tests__/AnalysisForm.test.jsx -t "formats iso"`
- `npx vitest run` *(fails: some tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_686864f9f724832f84c5b02124c43f1c