### PR TITLE
Fix year filter for Turkish date headers

### DIFF
--- a/ComplaintSearch/claims_excel.py
+++ b/ComplaintSearch/claims_excel.py
@@ -14,6 +14,9 @@ from importlib import resources
 from difflib import SequenceMatcher
 from openpyxl import load_workbook
 
+# Normalized header names considered as date columns
+DATE_KEYS = {"date", "tarih", "hata tarihi"}
+
 from . import normalize_text
 
 
@@ -90,13 +93,14 @@ class ExcelClaimsSearcher:
             return []
         results: List[Dict[str, Any]] = []
 
+        date_key = next((k for k in DATE_KEYS if k in indices), None)
         for row in rows:
             record = {
                 key: row[idx] if idx < len(row) else None
                 for key, idx in indices.items()
             }
-            if "date" in indices:
-                value = record.get("date")
+            if date_key is not None:
+                value = record.get(date_key)
                 if isinstance(value, str):
                     try:
                         value = datetime.fromisoformat(value)

--- a/tests/test_claims_excel.py
+++ b/tests/test_claims_excel.py
@@ -72,6 +72,25 @@ class ExcelClaimsSearchTest(unittest.TestCase):
             self.assertIn("musteri", result[0])
             self.assertEqual(result[0]["musteri"], "ACME")
 
+    def test_hata_tarihi_header(self) -> None:
+        """Year filters should work with 'Hata Tarihi' header."""
+        headers = [
+            "müşteri şikayeti",
+            "müşteri",
+            "konu",
+            "parça kodu",
+            "hata tarihi",
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "claims.xlsx")
+            self._create_file(file_path, headers=headers)
+            searcher = ExcelClaimsSearcher(file_path)
+            result = searcher.search({"müşteri": "ACME"}, year=2023)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["musteri"], "ACME")
+            empty = searcher.search({"müşteri": "ACME"}, year=2022)
+            self.assertEqual(empty, [])
+
     def test_dynamic_header_detection(self) -> None:
         """Headers should be detected after initial metadata rows."""
         file_path = Path("CC/F160_Customer_Claims.xlsx")


### PR DESCRIPTION
## Summary
- expand `ExcelClaimsSearcher` to recognize Turkish date headers
- test year filtering with `Hata Tarihi` column

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_686869097878832f9f9a61bb741db77f