### PR TITLE
Add sticky header test for claims table

### DIFF
--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -180,6 +180,26 @@ test('shows message when no claims returned', async () => {
   expect(screen.getByText('Kayıt bulunamadı')).toBeInTheDocument()
 })
 
+test('claims table uses sticky header', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { excel: [{ complaint: 'x' }], store: [] } })
+    })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.click(screen.getByRole('button', { name: /şikayetleri getir/i }))
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+  const table = await screen.findByRole('table')
+  expect(table.className).toMatch(/MuiTable-stickyHeader/)
+})
+
 test('applies instructionsBoxProps margin', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })


### PR DESCRIPTION
## Summary
- verify the claims table uses MUI sticky header

## Testing
- `python -m unittest discover`
- `npm test --silent -- --run` *(fails: 5 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_b_686986728b8c832fb583d7c68d8c9d01