### PR TITLE
Update table layout for long column names

### DIFF
--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -612,7 +612,7 @@ function AnalysisForm({
                 border: '1px solid #ccc',
                 minWidth: 650,
                 width: '100%',
-                tableLayout: 'fixed'
+                tableLayout: 'auto'
               }}
             >
               <TableHead>
@@ -624,9 +624,7 @@ function AnalysisForm({
                           style={{
                             maxWidth: 120,
                             display: 'inline-block',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap'
+                            
                           }}
                         >
                           {prettify(col)}
@@ -640,15 +638,7 @@ function AnalysisForm({
                 {claims.map((c, i) => (
                   <TableRow key={i}>
                     {Object.keys(claims[0]).map((col) => (
-                      <TableCell
-                        key={col}
-                        sx={{
-                          maxWidth: 200,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap'
-                        }}
-                      >
+                      <TableCell key={col}>
                         {formatDate(c[col])}
                       </TableCell>
                     ))}


### PR DESCRIPTION
## Summary
- allow table columns to grow with `tableLayout: 'auto'`
- display full header and cell text by removing ellipsis styling

## Testing
- `python -m unittest discover`
- `npx vitest run` *(fails: 5 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_b_6869c3887ccc832f90b24e837348afac