### PR TITLE
Fix UI scale with smaller components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,7 +24,14 @@ function App() {
         },
         shape: { borderRadius: 12 },
         typography: {
-          fontFamily: "'Poppins','Inter','Roboto','Helvetica','Arial',sans-serif"
+          fontFamily: "'Poppins','Inter','Roboto','Helvetica','Arial',sans-serif",
+          fontSize: 14
+        },
+        components: {
+          MuiButton: { defaultProps: { size: 'small' } },
+          MuiTextField: { defaultProps: { size: 'small' } },
+          MuiSelect: { defaultProps: { size: 'small' } },
+          MuiAutocomplete: { defaultProps: { size: 'small' } }
         }
       }),
     [mode]


### PR DESCRIPTION
## Summary
- reduce UI font size and make default component size small

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_6869cf5e9e94832f9dd50061fa0d705b