### PR TITLE
Add 8D report scanning button and backend

### DIFF
--- a/EightDScanner/__init__.py
+++ b/EightDScanner/__init__.py
@@ -1,0 +1,85 @@
+"""Scan 8D report Excel files and store results in SQLite."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List
+
+from openpyxl import load_workbook
+
+
+class EightDScanner:
+    """Scan Excel reports for key fields and persist them."""
+
+    def __init__(self, reports_dir: str | Path, db_path: str | Path = "eight_d.db") -> None:
+        self.reports_dir = Path(reports_dir)
+        self.reports_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = Path(db_path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reports (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    material_code TEXT,
+                    description TEXT,
+                    customer TEXT,
+                    root_cause TEXT,
+                    permanent_action TEXT
+                )
+                """
+            )
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return text.strip().lower().replace(" ", "")
+
+    def _extract_rows(self, path: Path) -> List[tuple[str, str, str, str, str]]:
+        wb = load_workbook(path, read_only=True)
+        ws = wb.active
+        rows = ws.iter_rows(values_only=True)
+        headers = [str(c).strip() if c is not None else "" for c in next(rows, [])]
+        mapping = {self._normalize(h): idx for idx, h in enumerate(headers)}
+        keys = {
+            "material_code": ["malzemekodu", "parcakodu"],
+            "description": ["tanım", "tanim"],
+            "customer": ["müşteri", "musteri"],
+            "root_cause": ["kökneden", "kokneden"],
+            "permanent_action": ["kalıcıaksiyon", "kaliciaksiyon"],
+        }
+        indices = {}
+        for field, aliases in keys.items():
+            for alias in aliases:
+                if alias in mapping:
+                    indices[field] = mapping[alias]
+                    break
+        results: List[tuple[str, str, str, str, str]] = []
+        if len(indices) < 5:
+            wb.close()
+            return results
+        for row in rows:
+            try:
+                values = [row[indices[f]] if indices[f] < len(row) else "" for f in indices]
+                results.append(tuple(str(v).strip() if v is not None else "" for v in values))
+            except Exception:
+                continue
+        wb.close()
+        return results
+
+    def scan(self) -> int:
+        """Scan all Excel files and persist extracted rows."""
+        count = 0
+        for path in self.reports_dir.glob("*.xlsx"):
+            rows = self._extract_rows(path)
+            with sqlite3.connect(self.db_path) as conn:
+                conn.executemany(
+                    "INSERT INTO reports(material_code, description, customer, root_cause, permanent_action) VALUES (?, ?, ?, ?, ?)",
+                    rows,
+                )
+                count += len(rows)
+        return count
+
+__all__ = ["EightDScanner"]

--- a/eight_d_reports/README.md
+++ b/eight_d_reports/README.md
@@ -1,0 +1,1 @@
+This directory stores 8D Excel reports for scanning.

--- a/frontend/src/__tests__/AnalysisForm.test.jsx
+++ b/frontend/src/__tests__/AnalysisForm.test.jsx
@@ -61,6 +61,21 @@ test('shows guide text when method selected', async () => {
   })
 })
 
+test('calls scan 8d endpoint on button click', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })
+    .mockResolvedValueOnce({ ok: true, text: async () => '' })
+
+  render(<AnalysisForm />)
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+
+  fireEvent.click(screen.getByRole('button', { name: /8d raporlarını tara/i }))
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+  expect(fetch.mock.calls[3][0]).toMatch(/scan_8d/)
+})
+
 test('fetches filtered claims', async () => {
   fetch
     .mockResolvedValueOnce({ ok: true, json: async () => ({ values: [] }) })

--- a/frontend/src/components/AnalysisForm.jsx
+++ b/frontend/src/components/AnalysisForm.jsx
@@ -302,6 +302,22 @@ function AnalysisForm({
       setClaims([]);
     }
   };
+
+  const handleScan8D = async () => {
+    try {
+      setError('');
+      setLoading(true);
+      const res = await fetch(`${API_BASE}/scan_8d`, { method: 'POST' });
+      if (!res.ok) {
+        setError(await res.text());
+      }
+    } catch (err) {
+      console.error(err);
+      setError(err.message || 'Bir hata oluştu');
+    } finally {
+      setLoading(false);
+    }
+  };
   return (
     <>
         {/* DEBUG: API'den gelen claims veri setini ve kolonlarını ham olarak ekranda göster */}
@@ -587,6 +603,9 @@ function AnalysisForm({
           </Button>
           <Button variant="outlined" color="primary" onClick={handleFetchClaims}>
             Şikayetleri Getir
+          </Button>
+          <Button variant="outlined" color="primary" onClick={handleScan8D}>
+            8D raporlarını tara
           </Button>
         </Box>
         {method && (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -172,6 +172,13 @@ class APITest(unittest.TestCase):
         self.assertIn("Guide method", logs)
         self.assertIn("Guide result", logs)
 
+    def test_scan_8d_endpoint(self) -> None:
+        with patch.object(api._scanner, "scan", return_value=5) as mock_scan:
+            response = self.client.post("/scan_8d")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok", "count": 5})
+        mock_scan.assert_called_once()
+
     def test_add_complaint_endpoint(self) -> None:
         body = {"complaint": "c", "customer": "cust", "subject": "s", "part_code": "p"}
         with patch.object(api._store, "add_complaint") as mock_add:

--- a/tests/test_eight_d_scanner.py
+++ b/tests/test_eight_d_scanner.py
@@ -1,0 +1,45 @@
+import sqlite3
+from pathlib import Path
+import unittest
+
+from EightDScanner import EightDScanner
+from openpyxl import Workbook
+
+
+class TestEightDScanner(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dir = Path("tests/temp_reports")
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.dir / "data.db"
+
+    def tearDown(self) -> None:
+        for item in self.dir.glob("*"):
+            item.unlink()
+        self.dir.rmdir()
+
+    def _create_excel(self, path: Path) -> None:
+        wb = Workbook()
+        ws = wb.active
+        ws.append([
+            "Malzeme Kodu",
+            "Tanım",
+            "Müşteri",
+            "Kök Neden",
+            "Kalıcı Aksiyon",
+        ])
+        ws.append(["123", "desc", "cust", "root", "action"])
+        wb.save(path)
+
+    def test_scan_inserts_rows(self) -> None:
+        file_path = self.dir / "test.xlsx"
+        self._create_excel(file_path)
+        scanner = EightDScanner(self.dir, self.db_path)
+        count = scanner.scan()
+        self.assertEqual(count, 1)
+        with sqlite3.connect(self.db_path) as conn:
+            rows = list(conn.execute("SELECT material_code, description, customer, root_cause, permanent_action FROM reports"))
+        self.assertEqual(rows, [("123", "desc", "cust", "root", "action")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create folder for 8D report excel files
- implement `EightDScanner` package for scanning Excel files into SQLite
- expose new `/scan_8d` API endpoint
- add button to UI to trigger scanning
- test new API and scanner
- test button click behaviour

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend test --silent` *(fails: see logs)*
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_b_687f65580578832f813408bec606c8c0